### PR TITLE
3 add authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 
 # ide
 /.vscode
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - React-flow package and workflow component. [#1](https://github.com/IN-CORE/incore-studio/issues/1)
+- Keycloak authentication to every route [#3](https://github.com/IN-CORE/incore-studio/issues/3)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "maplibre-gl-basemaps": "^0.1.2",
                 "react": "^18.2",
                 "react-dom": "^18.2",
+                "react-oidc-context": "^3.1.1",
                 "react-redux": "^9.1.2",
                 "react-router-dom": "^6.15",
                 "react-router-hash-link": "^2.4.3"
@@ -9463,6 +9464,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/jwt-decode": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/kdbush": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
@@ -10354,6 +10364,18 @@
             "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true
+        },
+        "node_modules/oidc-client-ts": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.0.1.tgz",
+            "integrity": "sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==",
+            "peer": true,
+            "dependencies": {
+                "jwt-decode": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
@@ -11511,6 +11533,18 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-oidc-context": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/react-oidc-context/-/react-oidc-context-3.1.1.tgz",
+            "integrity": "sha512-pXZYVUVOU+wnLFZVh5HFGiAyAHpy0mm7mZBVp5oNuCln/7yd+Uhb7KfYI2QN+LLQI0kIv6FHIcqeUFjMIsM5gA==",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "oidc-client-ts": "^3.0.0",
+                "react": ">=16.8.0"
+            }
         },
         "node_modules/react-redux": {
             "version": "9.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "axios": "~1.4",
                 "maplibre-gl": "^2.4.0",
                 "maplibre-gl-basemaps": "^0.1.2",
+                "oidc-client-ts": "^3.0.1",
                 "react": "^18.2",
                 "react-dom": "^18.2",
                 "react-oidc-context": "^3.1.1",
@@ -9888,7 +9889,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
             "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -10789,7 +10789,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.0.1.tgz",
             "integrity": "sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==",
-            "peer": true,
             "dependencies": {
                 "jwt-decode": "^4.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "maplibre-gl-basemaps": "^0.1.2",
         "react": "^18.2",
         "react-dom": "^18.2",
+        "react-oidc-context": "^3.1.1",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.15",
         "react-router-hash-link": "^2.4.3"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "axios": "~1.4",
         "maplibre-gl": "^2.4.0",
         "maplibre-gl-basemaps": "^0.1.2",
+        "oidc-client-ts": "^3.0.1",
         "react": "^18.2",
         "react-dom": "^18.2",
         "react-oidc-context": "^3.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,13 @@
-import React, { StrictMode, Suspense, FC } from "react";
+import React, { StrictMode, Suspense, FC, useEffect } from "react";
 // eslint-disable-next-line import/no-unresolved
 import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { CssVarsProvider } from "@mui/joy/styles";
-import { AuthProvider } from "react-oidc-context";
+import { AuthProvider, useAuth } from "react-oidc-context";
 
 import CssBaseline from "@mui/joy/CssBaseline";
 import "@fontsource/inter";
 import "@xyflow/react/dist/style.css";
-
 
 import routes from "./routes";
 import { theme } from "./theme";
@@ -25,6 +24,27 @@ const oidcConfig = {
 };
 
 const App: FC = () => {
+    const auth = useAuth();
+    // const navigate = useNavigate();
+
+    useEffect(() => {
+        if (auth.isLoading) return; // Do nothing while loading
+
+        if (!auth.isAuthenticated) {
+            auth.signinRedirect().catch((error) => {
+                console.error("Login error:", error);
+            });
+        }
+    }, [auth.isLoading, auth.isAuthenticated]);
+
+    if (auth.isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (auth.error) {
+        return <div>Oops... {auth.error.message}</div>;
+    }
+
     return (
         <StrictMode>
             <Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,6 @@ const oidcConfig = {
 
 const App: FC = () => {
     const auth = useAuth();
-    // const navigate = useNavigate();
 
     useEffect(() => {
         if (auth.isLoading) return; // Do nothing while loading

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,12 @@ import React, { StrictMode, Suspense, FC } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { CssVarsProvider } from "@mui/joy/styles";
+import { AuthProvider } from "react-oidc-context";
+
 import CssBaseline from "@mui/joy/CssBaseline";
 import "@fontsource/inter";
 import "@xyflow/react/dist/style.css";
+
 
 import routes from "./routes";
 import { theme } from "./theme";
@@ -14,6 +17,12 @@ import Loading from "./components/Loading";
 import "./styles/main.scss";
 
 window.API_PATH = `${window.API_SERVER}/datawolf/api`;
+
+const oidcConfig = {
+    authority: window.AUTHORITY,
+    client_id: window.CLIENT_ID,
+    redirect_uri: window.REDIRECT_URI
+};
 
 const App: FC = () => {
     return (
@@ -36,7 +45,11 @@ const App: FC = () => {
 
 const rootEl = document.getElementById("root");
 if (rootEl) {
-    createRoot(rootEl).render(<App />);
+    createRoot(rootEl).render(
+        <AuthProvider {...oidcConfig}>
+            <App />
+        </AuthProvider>
+    );
 }
 
 export default App;

--- a/src/components/Execution/index.tsx
+++ b/src/components/Execution/index.tsx
@@ -3,14 +3,18 @@ import React from "react";
 import Box from "@mui/joy/Box";
 
 import Workflow from "../Workflow";
+import Topbar from "@app/components/Home/Topbar";
 
 const Execution = (): JSX.Element => {
     return (
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
-            <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-                <Workflow />
+        <>
+            <Topbar />
+            <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+                <Box sx={{ flexGrow: 1, overflow: "auto" }}>
+                    <Workflow />
+                </Box>
             </Box>
-        </Box>
+        </>
     );
 };
 

--- a/src/components/Home/Topbar.tsx
+++ b/src/components/Home/Topbar.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Box, Typography, Button } from "@mui/joy";
+import { useAuth } from "react-oidc-context";
+
+const Topbar: React.FC = () => {
+    const auth = useAuth();
+    const handleLogout = () => {
+        auth.signoutPopup().catch((error) => {
+            console.error("Login error:", error);
+        });
+    };
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                bgcolor: "primary.main",
+                color: "white",
+                p: 2,
+                boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)",
+                position: "sticky",
+                top: 0,
+                width: "100%"
+            }}
+        >
+            <Typography level="h4" sx={{ flexGrow: 1 }}>
+                IN-CORE Studio
+            </Typography>
+            <Button color="primary" onClick={handleLogout} variant="plain">
+                Log out
+            </Button>
+        </Box>
+    );
+};
+
+export default Topbar;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,21 +1,23 @@
 import React from "react";
-import {Box} from "@mui/joy";
+import { Box } from "@mui/joy";
 
 import Workflow from "../Workflow";
-
+import Topbar from "./Topbar";
 
 const Home = (): JSX.Element => {
     return (
-        <Box sx={{display: "flex", flexDirection: "column", height: "100vh"}}>
-            <Box sx={{flexShrink: 0}}>
-                <h1>Home</h1>
+        <>
+            <Topbar />
+            <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
+                <Box sx={{ flexShrink: 0 }}>
+                    <h1>Home</h1>
+                </Box>
+                <Box sx={{ flexGrow: 1, overflow: "auto" }}>
+                    <Workflow />
+                </Box>
             </Box>
-            <Box sx={{flexGrow: 1, overflow: "auto"}}>
-                <Workflow/>
-            </Box>
-        </Box>
+        </>
     );
-
 };
 
 export default Home;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,50 +1,21 @@
-import React, {useEffect} from "react";
-import {useNavigate} from "react-router-dom";
-import {Button, Box} from "@mui/joy";
-import {useAuth} from "react-oidc-context";
+import React from "react";
+import {Box} from "@mui/joy";
 
 import Workflow from "../Workflow";
 
 
 const Home = (): JSX.Element => {
-    const auth = useAuth();
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        if (auth.isAuthenticated) {
-            // Remove query parameters from URL
-            navigate(window.location.pathname, { replace: true });
-        }
-    }, [auth.isAuthenticated, navigate]);
-
-    if (auth.isLoading) {
-        return <div>Loading...</div>;
-    }
-
-    if (auth.error) {
-        return <div>Oops... {auth.error.message}</div>;
-    }
-
-    const handleLogin = () => {
-        auth.signinRedirect().catch(error => {
-            console.error('Login error:', error);
-        });
-    };
-
-    if (auth.isAuthenticated) {
-        return (
-            <Box sx={{display: "flex", flexDirection: "column", height: "100vh"}}>
-                <Box sx={{flexShrink: 0}}>
-                    <h1>Home</h1>
-                </Box>
-                <Box sx={{flexGrow: 1, overflow: "auto"}}>
-                    <Workflow/>
-                </Box>
+    return (
+        <Box sx={{display: "flex", flexDirection: "column", height: "100vh"}}>
+            <Box sx={{flexShrink: 0}}>
+                <h1>Home</h1>
             </Box>
-        );
-    }
+            <Box sx={{flexGrow: 1, overflow: "auto"}}>
+                <Workflow/>
+            </Box>
+        </Box>
+    );
 
-    return <Button onClick={handleLogin}>Log in</Button>;
 };
 
 export default Home;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -16,6 +16,12 @@ const Home = (): JSX.Element => {
         return <div>Oops... {auth.error.message}</div>;
     }
 
+    const handleLogin = () => {
+        auth.signinRedirect().catch(error => {
+            console.error('Login error:', error);
+        });
+    };
+
     if (auth.isAuthenticated) {
         return (
             <Box sx={{display: "flex", flexDirection: "column", height: "100vh"}}>
@@ -29,7 +35,7 @@ const Home = (): JSX.Element => {
         );
     }
 
-    return <Button onClick={auth.signinRedirect}>Log in</Button>;
+    return <Button onClick={handleLogin}>Log in</Button>;
 };
 
 export default Home;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Box } from "@mui/joy";
 
-import Workflow from "../Workflow";
 import Topbar from "./Topbar";
 
 const Home = (): JSX.Element => {
@@ -11,9 +10,6 @@ const Home = (): JSX.Element => {
             <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
                 <Box sx={{ flexShrink: 0 }}>
                     <h1>Home</h1>
-                </Box>
-                <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-                    <Workflow />
                 </Box>
             </Box>
         </>

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, {useEffect} from "react";
+import {useNavigate} from "react-router-dom";
 import {Button, Box} from "@mui/joy";
 import {useAuth} from "react-oidc-context";
 
@@ -7,6 +8,14 @@ import Workflow from "../Workflow";
 
 const Home = (): JSX.Element => {
     const auth = useAuth();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (auth.isAuthenticated) {
+            // Remove query parameters from URL
+            navigate(window.location.pathname, { replace: true });
+        }
+    }, [auth.isAuthenticated, navigate]);
 
     if (auth.isLoading) {
         return <div>Loading...</div>;

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,19 +1,35 @@
 import React from "react";
-import Box from "@mui/joy/Box";
+import {Button, Box} from "@mui/joy";
+import {useAuth} from "react-oidc-context";
 
 import Workflow from "../Workflow";
 
+
 const Home = (): JSX.Element => {
-    return (
-        <Box sx={{ display: "flex", flexDirection: "column", height: "100vh" }}>
-            <Box sx={{ flexShrink: 0 }}>
-                <h1>Home</h1>
+    const auth = useAuth();
+
+    if (auth.isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (auth.error) {
+        return <div>Oops... {auth.error.message}</div>;
+    }
+
+    if (auth.isAuthenticated) {
+        return (
+            <Box sx={{display: "flex", flexDirection: "column", height: "100vh"}}>
+                <Box sx={{flexShrink: 0}}>
+                    <h1>Home</h1>
+                </Box>
+                <Box sx={{flexGrow: 1, overflow: "auto"}}>
+                    <Workflow/>
+                </Box>
             </Box>
-            <Box sx={{ flexGrow: 1, overflow: "auto" }}>
-                <Workflow />
-            </Box>
-        </Box>
-    );
+        );
+    }
+
+    return <Button onClick={auth.signinRedirect}>Log in</Button>;
 };
 
 export default Home;

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
 window.API_SERVER = process.env.API_SERVER || "http://localhost:8000";
-window.AUTHORITY = process.env.AUTHORITY || "http://incore-dev.ncsa.illinois.edu/auth/realms/in-core";
+window.AUTHORITY = process.env.AUTHORITY || "https://incore-dev.ncsa.illinois.edu/auth/realms/In-core";
 window.CLIENT_ID = process.env.CLIENT_ID || "react-auth";
 window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:3000";

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
 window.API_SERVER = process.env.API_SERVER || "http://localhost:8000";
-window.AUTHORITY = process.env.AUTHORITY || "http://localhost:8000";
-window.CLIENT_ID = process.env.CLIENT_ID || "client_id";
-window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:8000";
+window.AUTHORITY = process.env.AUTHORITY || "http://incore-dev.ncsa.illinois.edu/auth/realms/in-core";
+window.CLIENT_ID = process.env.CLIENT_ID || "react-auth";
+window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:3000";

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,4 @@
 window.API_SERVER = process.env.API_SERVER || "http://localhost:8000";
+window.AUTHORITY = process.env.AUTHORITY || "http://localhost:8000";
+window.CLIENT_ID = process.env.CLIENT_ID || "client_id";
+window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:8000";

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
 window.API_SERVER = process.env.API_SERVER || "http://localhost:8000";
 window.AUTHORITY = process.env.AUTHORITY || "https://incore-dev.ncsa.illinois.edu/auth/realms/In-core";
 window.CLIENT_ID = process.env.CLIENT_ID || "react-auth";
-window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:3000";
+window.REDIRECT_URI = process.env.REDIRECT_URI || "http://localhost:3000/";

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,9 @@
 interface Window {
     API_SERVER: string;
     API_PATH: string;
+    AUTHORITY: string;
+    CLIENT_ID: string;
+    REDIRECT_URI: string;
 }
 
 declare module "*.json" {


### PR DESCRIPTION
Visu recommended this convenient library "react-oidc-context" which is build upon [oidc-client-js](https://github.com/IdentityModel/oidc-client-js/wiki)

This handles redirect login/logout elegantly. The user information will be stored in session storage. 
Every route is protected at the moment.

Go to `http://localhost:3000`; if not authenticated, it will redirect to keycloak login and redirect back
When log out, I took the signoutPopup() approach which will popup new window. But I could try just signoutRedirect approach which will stay on the sign out page.

Also implemented a minimalist navigation bar since I saw there are other tasks designated for that.

<img width="1459" alt="image" src="https://github.com/user-attachments/assets/2311cd04-13e7-40b3-8bd6-e48f222d20ca">
