### PR TITLE
add support to add result datasets

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -50,7 +50,7 @@ jobs:
 
           # calculate the version and all tags
           if [ "$BRANCH" == "main" ]; then
-            VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g') 
+            VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')
             tags="latest"
             oldversion=""
             tmpversion="${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Support to automatically add the result datasets to project. [#70](https://github.com/IN-CORE/incore-studio/issues/70)
+
 ## [Alpha-1] - 01-09-2025
 
 ### Added

--- a/src/components/Execution/OutputFileDisplay.tsx
+++ b/src/components/Execution/OutputFileDisplay.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import axios from "axios";
 
-import { Box, Stack, Input, IconButton, Tooltip } from "@mui/joy";
+import { Box, Stack, Input, IconButton, Snackbar, Tooltip } from "@mui/joy";
 import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
 import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
 
@@ -21,6 +21,9 @@ const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projec
     const [dataset, setDataset] = React.useState<Dataset | null>(null);
     const [selectedDataset, setSelectedDataset] = React.useState<Dataset | null>(null);
     const appDispatch = useAppDispatch();
+    const [snackbarOpen, setSnackbarOpen] = React.useState<boolean>(false);
+    const [snackbarMessage, setSnackbarMessage] = React.useState<string>("");
+    const [snackbarColor, setSnackbarColor] = React.useState<"success" | "danger" | "warning" | "neutral">("neutral");
 
     React.useEffect(() => {
         if (datasetId !== "" && datasetId !== "N/A" && datasetId !== "ERROR" && datasetId !== "Not present") {
@@ -48,6 +51,10 @@ const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projec
     };
     const handleAddVisualization = (visualizationId: string) => {
         if (selectedDataset && projectId) {
+            console.log("Adding to Visualization...");
+            setSnackbarMessage("Adding to Visualization...");
+            setSnackbarColor("warning");
+            setSnackbarOpen(true);
             if (selectedDataset.format === "shapefile") {
                 const layers = [
                     {
@@ -55,11 +62,23 @@ const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projec
                         layerId: selectedDataset.id
                     }
                 ];
-
-                // Dispatch the action with the new layers array
-                appDispatch(addLayerToVisualization({ projectId, visualizationId, layers }));
+                try {
+                    // Dispatch the action with the new layers array
+                    appDispatch(addLayerToVisualization({ projectId, visualizationId, layers }));
+                    setSnackbarMessage("Successfully added to Visualization!");
+                    setSnackbarColor("success");
+                    setSnackbarOpen(true);
+                } catch (error) {
+                    console.error("Error adding layer to visualization", error);
+                    setSnackbarMessage("Error adding to Visualization!");
+                    setSnackbarColor("danger");
+                    setSnackbarOpen(true);
+                }
             } else {
                 alert("Only shapefiles can be added to a visualization for now!");
+                setSnackbarMessage("Error adding to Visualization!");
+                setSnackbarColor("danger");
+                setSnackbarOpen(true);
             }
             setSelectedDataset(null);
         }
@@ -106,6 +125,7 @@ const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projec
                         color="neutral"
                         aria-label="Add to Visualization"
                         onClick={() => {
+                            setSelectedDataset(dataset);
                             setOpenVisDialog(true);
                         }}
                     >
@@ -119,6 +139,20 @@ const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projec
                 onClose={handleCloseVisDialog}
                 onAddVisualization={handleAddVisualization}
             />
+            <Snackbar
+                anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                open={snackbarOpen}
+                onClose={() => {
+                    setSnackbarOpen(false);
+                    setSnackbarMessage("");
+                    setSnackbarColor("neutral");
+                }}
+                variant="outlined"
+                color={snackbarColor}
+                autoHideDuration={2000}
+            >
+                {snackbarMessage}
+            </Snackbar>
         </Box>
     );
 };

--- a/src/components/Execution/OutputFileDisplay.tsx
+++ b/src/components/Execution/OutputFileDisplay.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import axios from "axios";
+
+import { Box, Stack, Input, IconButton, Tooltip } from "@mui/joy";
+import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
+import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
+
+import config from "@app/app.config";
+import { getHeaders } from "@app/utils";
+import { addLayerToVisualization } from "@app/reducer/projectSlice";
+import { useAppDispatch } from "@app/store/hooks";
+import { VisualizationDialog } from "@app/components/Project/Resource/VisualizationDialog";
+
+interface OutputFileDisplayProps {
+    datasetId: string;
+    projectId: string | undefined;
+}
+
+const OutputFileDisplay: React.FC<OutputFileDisplayProps> = ({ datasetId, projectId }) => {
+    const [copied, setCopied] = React.useState(false);
+    const [dataset, setDataset] = React.useState<Dataset | null>(null);
+    const [selectedDataset, setSelectedDataset] = React.useState<Dataset | null>(null);
+    const appDispatch = useAppDispatch();
+
+    React.useEffect(() => {
+        if (datasetId !== "" && datasetId !== "N/A" && datasetId !== "ERROR" && datasetId !== "Not present") {
+            const fetchDataset = async () => {
+                try {
+                    const response = await axios.get<Dataset>(`${config.hostname}/data/api/datasets/${datasetId}`, {
+                        headers: getHeaders()
+                    });
+                    if (response.status === 200) {
+                        setDataset(response.data);
+                    }
+                } catch (error) {
+                    console.error("Error fetching dataset", error);
+                }
+            };
+
+            fetchDataset();
+        }
+    }, []);
+
+    // add to visualization
+    const [openVisDialog, setOpenVisDialog] = React.useState(false);
+    const handleCloseVisDialog = () => {
+        setOpenVisDialog(false);
+    };
+    const handleAddVisualization = (visualizationId: string) => {
+        if (selectedDataset && projectId) {
+            if (selectedDataset.format === "shapefile") {
+                const layers = [
+                    {
+                        workspace: "incore",
+                        layerId: selectedDataset.id
+                    }
+                ];
+
+                // Dispatch the action with the new layers array
+                appDispatch(addLayerToVisualization({ projectId, visualizationId, layers }));
+            } else {
+                alert("Only shapefiles can be added to a visualization for now!");
+            }
+            setSelectedDataset(null);
+        }
+        setOpenVisDialog(false);
+    };
+
+    return (
+        <Box>
+            <Stack direction="row" spacing={1}>
+                <Input
+                    fullWidth
+                    value={
+                        dataset === null
+                            ? datasetId
+                            : dataset.fileDescriptors !== undefined && dataset.fileDescriptors.length > 0
+                              ? dataset.fileDescriptors[0].filename
+                              : datasetId
+                    }
+                    variant="outlined"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => e.preventDefault()}
+                    // sx={{
+                    //     "&.Mui-disabled": {
+                    //         color: "#1E293B"
+                    //     }
+                    // }}
+                />
+                <Tooltip title={copied ? "Copied!" : "Copy ID to Clipboard"} placement="bottom">
+                    <IconButton
+                        variant="soft"
+                        color={copied ? "success" : "neutral"}
+                        onClick={() => {
+                            navigator.clipboard.writeText(datasetId).then(() => {
+                                setCopied(true);
+                                setTimeout(() => setCopied(false), 2000); // Reset after 2 seconds
+                            });
+                        }}
+                    >
+                        <ContentCopyRoundedIcon />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="Add to Visualization" placement="bottom">
+                    <IconButton
+                        variant="soft"
+                        color="neutral"
+                        aria-label="Add to Visualization"
+                        onClick={() => {
+                            setOpenVisDialog(true);
+                        }}
+                    >
+                        <BookmarkAddRoundedIcon />
+                    </IconButton>
+                </Tooltip>
+            </Stack>
+            <VisualizationDialog
+                projectId={projectId || ""}
+                open={openVisDialog}
+                onClose={handleCloseVisDialog}
+                onAddVisualization={handleAddVisualization}
+            />
+        </Box>
+    );
+};
+
+export default OutputFileDisplay;

--- a/src/components/Execution/SidePanel.tsx
+++ b/src/components/Execution/SidePanel.tsx
@@ -8,7 +8,6 @@ import {
     Box,
     Button,
     Divider,
-    Grid,
     IconButton,
     Input,
     Option,
@@ -25,9 +24,10 @@ import {
 } from "@mui/joy";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import StorageIcon from "@mui/icons-material/Storage";
-import BookmarkAddRoundedIcon from "@mui/icons-material/BookmarkAddRounded";
 import FileDownloadRoundedIcon from "@mui/icons-material/FileDownloadRounded";
 import AddIcon from "@mui/icons-material/Add";
+import VisibilityRoundedIcon from "@mui/icons-material/VisibilityRounded";
+import InsertChartOutlinedRoundedIcon from "@mui/icons-material/InsertChartOutlinedRounded";
 
 import {
     updateCreateExecutionTemplateDatasetAndParams,
@@ -38,11 +38,14 @@ import {
     addDatasetToProject,
     addDFR3MappingToProject,
     addHazardToProject,
-    getProject
+    getProject,
+    getProjectVisualizations
 } from "@app/reducer/projectSlice";
+import { VisualizationView } from "@app/components/Project/Resource/VisaualizationView";
 
 import { useAppDispatch, useAppSelector } from "@app/store/hooks";
 import { AddFromServiceDialog } from "@app/components/Project/Resource/AddFromServiceDialog";
+import OutputFileDisplay from "./OutputFileDisplay";
 
 const SidePanel: React.FC<{ createMode: boolean }> = ({ createMode }) => {
     const appDispatch = useAppDispatch();
@@ -141,6 +144,15 @@ const SidePanel: React.FC<{ createMode: boolean }> = ({ createMode }) => {
         appDispatch(clearSidePanelData());
     };
 
+    React.useEffect(() => {
+        if (id) {
+            // get all visualizations
+            appDispatch(getProjectVisualizations({ projectId: id, skip: 0, limit: 100000 }));
+        }
+    }, []);
+
+    const projectVisualizations = useAppSelector((state) => state.project.projectVisualizations);
+
     // Add dataset to project from service
     const [openAddDatasetFromServiceDialog, setOpenAddDatasetFromServiceDialog] = React.useState(false);
     const addDatasetFunc = (projectId: string, resource: Dataset) => {
@@ -158,9 +170,15 @@ const SidePanel: React.FC<{ createMode: boolean }> = ({ createMode }) => {
     // Add hazard to project from service
     const [openAddDFR3MappingFromServiceDialog, setOpenAddDFR3MappingFromServiceDialog] = React.useState(false);
     const addDFR3MappingFunc = (projectId: string, resource: DFR3Mapping) => {
-        console.log(resource);
         appDispatch(addDFR3MappingToProject({ projectId, dfr3Mappings: [resource] }));
         setOpenAddDFR3MappingFromServiceDialog(false);
+    };
+
+    // View visualization
+    const [selectedVisualization, setSelectedVisualization] = React.useState<Visualization>();
+    const [openVisualziationView, setOpenVisualziationView] = React.useState(true);
+    const handleCloseVisualziationView = () => {
+        setOpenVisualziationView(false);
     };
 
     const downloadFile = async (datasetId: string) => {
@@ -283,6 +301,9 @@ const SidePanel: React.FC<{ createMode: boolean }> = ({ createMode }) => {
                         </Tab>
                         <Tab variant="soft" sx={{ flexGrow: 1 }} disabled={createMode}>
                             Results
+                        </Tab>
+                        <Tab variant="soft" sx={{ flexGrow: 1 }} disabled={createMode}>
+                            Visualizations
                         </Tab>
                     </TabList>
 
@@ -581,58 +602,139 @@ const SidePanel: React.FC<{ createMode: boolean }> = ({ createMode }) => {
                             <Stack direction="column" spacing={2}>
                                 {sidePanelData.currentAnalysis.outputDatasets.map((outputDataset) => (
                                     <Box key={outputDataset.execFileEntryId}>
-                                        <Stack direction="row" spacing={2} alignItems="center" mb={1}>
-                                            <StorageIcon
-                                                sx={{
-                                                    color: "#AB47BC",
-                                                    marginRight: "5px",
-                                                    pointerEvents: "none",
-                                                    fontSize: "15px"
-                                                }}
-                                            />
-                                            <Typography
-                                                level="h4"
-                                                sx={{
-                                                    fontWeight: 400,
-                                                    fontSize: "14px",
-                                                    lineHeight: "24px",
-                                                    paragraph: "28px",
-                                                    color: "#172B4D"
-                                                }}
-                                            >
-                                                {outputDataset.label}
-                                            </Typography>
-                                        </Stack>
-                                        <Grid container spacing={1} sx={{ flexGrow: 1 }}>
-                                            <Grid xs={10} component="div">
-                                                <Input
-                                                    disabled
-                                                    value={outputDataset.datasetId}
-                                                    variant="solid"
+                                        <Stack
+                                            direction="row"
+                                            spacing={2}
+                                            alignItems="center"
+                                            justifyContent="space-between"
+                                            mb={1}
+                                        >
+                                            <Stack direction="row" spacing={2} alignItems="center">
+                                                <StorageIcon
                                                     sx={{
-                                                        "&.Mui-disabled": {
-                                                            color: "#1E293B"
-                                                        }
+                                                        color: "#AB47BC",
+                                                        marginRight: "5px",
+                                                        pointerEvents: "none",
+                                                        fontSize: "15px"
                                                     }}
                                                 />
-                                            </Grid>
-                                            <Grid xs={1} component="div">
-                                                <Tooltip title="Add to Visualization" placement="bottom">
-                                                    <IconButton>
-                                                        <BookmarkAddRoundedIcon />
-                                                    </IconButton>
-                                                </Tooltip>
-                                            </Grid>
-                                            <Grid xs={1} component="div">
-                                                <Tooltip title="Download file" placement="bottom">
-                                                    <IconButton onClick={() => downloadFile(outputDataset.datasetId)}>
+                                                <Typography
+                                                    level="h4"
+                                                    sx={{
+                                                        fontWeight: 400,
+                                                        fontSize: "14px",
+                                                        lineHeight: "24px",
+                                                        paragraph: "28px",
+                                                        color: "#172B4D"
+                                                    }}
+                                                >
+                                                    {outputDataset.label}
+                                                </Typography>
+                                            </Stack>
+                                            <Box>
+                                                <Tooltip title="Download file" placement="top-start">
+                                                    <IconButton
+                                                        aria-label="Download file"
+                                                        onClick={() => downloadFile(outputDataset.datasetId)}
+                                                    >
                                                         <FileDownloadRoundedIcon />
                                                     </IconButton>
                                                 </Tooltip>
-                                            </Grid>
-                                        </Grid>
+                                            </Box>
+                                        </Stack>
+                                        <OutputFileDisplay datasetId={outputDataset.datasetId} projectId={id} />
                                     </Box>
                                 ))}
+                            </Stack>
+                        </Box>
+                    </TabPanel>
+                    <TabPanel value={2}>
+                        <Box>
+                            <Typography
+                                level="h4"
+                                sx={{
+                                    fontWeight: 590,
+                                    fontSize: "16px",
+                                    lineHeight: "24px",
+                                    paragraph: "28px",
+                                    color: "#172B4D",
+                                    letter: "5%",
+                                    textTransform: "uppercase",
+                                    mb: "5px"
+                                }}
+                            >
+                                Visualizations
+                            </Typography>
+                            <Typography
+                                level="h4"
+                                sx={{
+                                    fontWeight: 400,
+                                    fontSize: "12px",
+                                    lineHeight: "20px",
+                                    color: "#42526EB2",
+                                    mb: "10px"
+                                }}
+                            >
+                                All available visualizations in this project.
+                            </Typography>
+                            <Stack direction="column" spacing={2}>
+                                {projectVisualizations.length === 0 ? (
+                                    <Typography>No visualizations available</Typography>
+                                ) : (
+                                    projectVisualizations.map((visualization) => (
+                                        <Box key={visualization.id}>
+                                            <Stack
+                                                direction="row"
+                                                spacing={2}
+                                                alignItems="center"
+                                                justifyContent="space-between"
+                                                mb={1}
+                                            >
+                                                <Stack direction="row" spacing={2} alignItems="center">
+                                                    <InsertChartOutlinedRoundedIcon
+                                                        sx={{
+                                                            color: "#AB47BC",
+                                                            marginRight: "5px",
+                                                            pointerEvents: "none"
+                                                        }}
+                                                    />
+                                                    <Typography
+                                                        level="body-sm"
+                                                        sx={{
+                                                            fontWeight: 400,
+                                                            fontSize: "16px",
+                                                            lineHeight: "24px",
+                                                            paragraph: "28px",
+                                                            color: "#172B4D"
+                                                        }}
+                                                    >
+                                                        {visualization.name}
+                                                    </Typography>
+                                                </Stack>
+                                                <Box>
+                                                    <Tooltip title="View visualization" placement="top-start">
+                                                        <IconButton
+                                                            aria-label="View visualization"
+                                                            onClick={() => {
+                                                                setSelectedVisualization(visualization);
+                                                                setOpenVisualziationView(true);
+                                                            }}
+                                                        >
+                                                            <VisibilityRoundedIcon />
+                                                        </IconButton>
+                                                    </Tooltip>
+                                                </Box>
+                                            </Stack>
+                                            {selectedVisualization && (
+                                                <VisualizationView
+                                                    visualization={selectedVisualization}
+                                                    open={openVisualziationView}
+                                                    onClose={handleCloseVisualziationView}
+                                                />
+                                            )}
+                                        </Box>
+                                    ))
+                                )}
                             </Stack>
                         </Box>
                     </TabPanel>

--- a/src/components/Project/ProjectPage.tsx
+++ b/src/components/Project/ProjectPage.tsx
@@ -29,7 +29,7 @@ import ResourceFilterBar from "@app/components/Project/Resource/ResourceFilterBa
 import Divider from "@mui/joy/Divider";
 import { ResourceCards } from "@app/components/Project/Resource/ResourceCards";
 import { ProjectSidebar } from "@app/components/Project/ProjectSidebar";
-import { useAppDispatch } from "@app/store/hooks";
+import { useAppDispatch, useOutputDatasetsSynchronizationPolling } from "@app/store/hooks";
 
 import DatasetIcon from "@mui/icons-material/FormatListBulleted";
 import WorkflowIcon from "@mui/icons-material/AccountTree";
@@ -95,6 +95,9 @@ const ProjectPage = (): JSX.Element => {
     const datasetPreviousPage = () => {
         setDatasetPageNumber((prevPage) => Math.max(prevPage - 1, 1)); // Prevent going below page 1
     };
+
+    // Synchronize all generated output datasets with the project datasets.
+    useOutputDatasetsSynchronizationPolling(projectWorkflows, 600000, id);
 
     // Fetch projects when filters or pagination change (but not during search)
     useEffect(() => {

--- a/src/components/Project/Resource/VisualizationDialog.tsx
+++ b/src/components/Project/Resource/VisualizationDialog.tsx
@@ -17,7 +17,7 @@ import {
 import { useSelector } from "react-redux";
 import { RootState } from "@app/store";
 import { useAppDispatch } from "@app/store/hooks";
-import { createProjectVisualization } from "@app/reducer/projectSlice";
+import { createProjectVisualization, getProjectVisualizations } from "@app/reducer/projectSlice";
 import config from "@app/app.config";
 
 interface VisualizationDialogProps {
@@ -40,6 +40,11 @@ export const VisualizationDialog: React.FC<VisualizationDialogProps> = ({
     const [description, setDescription] = useState("");
     const [boundingBox, setBoundingBox] = useState("");
     const [styleName, setStyleName] = useState("");
+
+    React.useEffect(() => {
+        // get all visualizations
+        appDispatch(getProjectVisualizations({ projectId, skip: 0, limit: 100000 }));
+    }, []);
 
     const appDispatch = useAppDispatch();
     const projectVisualizations = useSelector((state: RootState) => state.project.projectVisualizations);

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,11 +1,12 @@
 import React from "react";
 import axios from "axios";
-import { getHeaders } from "@app/utils";
+import { getHeaders, getOutputDatasetIDsFromWorkflows } from "@app/utils";
 import config from "@app/app.config";
 
 import { useDispatch, useSelector } from "react-redux";
 import type { RootState, AppDispatch } from "@app/store";
 import { setCreateExecutionTemplate, setCurrentExecution } from "@app/reducer/executionSlice";
+import { addDatasetToProject } from "@app/reducer/projectSlice";
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
@@ -74,4 +75,72 @@ export const useExecutionPolling = (executionId: string | null, interval: number
         // cleanup
         return () => clearInterval(intervalId);
     }, [executionId, interval, appDispatch]);
+};
+
+const fetchDatasetsFromService = async (datasetIds: string[]): Promise<Dataset[]> => {
+    try {
+        const requests = datasetIds.map((id) =>
+            axios.get<Dataset>(`${config.hostname}/data/api/datasets/${id}`, { headers: getHeaders() })
+        );
+        const responses = await Promise.all(requests);
+
+        const datasets = responses.map((response) => response.data);
+        return datasets;
+    } catch (error) {
+        console.error("Error fetching datasets: ", error);
+        throw new Error("Error fetching datasets");
+    }
+};
+
+export const useOutputDatasetsSynchronizationPolling = (
+    projectWorkflows: Workflow[],
+    interval: number,
+    projectId: string | undefined
+) => {
+    const projectDatasets = useSelector((state: RootState) => state.project.projectDatasets);
+    const appDispatch = useAppDispatch();
+
+    const fetchWorkflowFiles = async (wfids: string[]): Promise<DatawolfWorkflowFile[]> => {
+        try {
+            const requests = wfids.map((wfid) =>
+                axios.get<DatawolfWorkflowFile>(`${config.datawolfApi}/workflows/${wfid}`, { headers: getHeaders() })
+            );
+            const responses = await Promise.all(requests);
+
+            const wfFiles = responses.map((response) => response.data);
+            return wfFiles;
+        } catch (error) {
+            console.error("Error fetching workflow files: ", error);
+            throw new Error("Error fetching workflow files");
+        }
+    };
+
+    React.useEffect(() => {
+        if (projectWorkflows.length === 0 || !interval || projectId === undefined) return;
+
+        const fetchAndSync = async () => {
+            let wfids = projectWorkflows.map((wf) => wf.id);
+            // fetch all workflow files
+            try {
+                const wfFiles = await fetchWorkflowFiles(wfids);
+                const outputDatasetIDs = await getOutputDatasetIDsFromWorkflows(wfFiles);
+                const datasetIdsNotInProject = outputDatasetIDs.filter(
+                    (id) => !projectDatasets.find((d) => d.id === id)
+                );
+                if (datasetIdsNotInProject.length > 0) {
+                    const newDatasets = await fetchDatasetsFromService(datasetIdsNotInProject);
+                    appDispatch(addDatasetToProject({ projectId: projectId, datasets: newDatasets }));
+                }
+            } catch (error) {
+                console.error("Error fetching workflow files: ", error);
+            }
+        };
+
+        fetchAndSync(); // initial fetch
+
+        const intervalId = setInterval(fetchAndSync, interval);
+
+        // cleanup
+        return () => clearInterval(intervalId);
+    }, [projectWorkflows, interval]);
 };

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -124,15 +124,15 @@ export const useOutputDatasetsSynchronizationPolling = (
             try {
                 const wfFiles = await fetchWorkflowFiles(wfids);
                 const outputDatasetIDs = await getOutputDatasetIDsFromWorkflows(wfFiles);
-                const datasetIdsNotInProject = outputDatasetIDs.filter(
-                    (id) => !projectDatasets.find((d) => d.id === id)
-                );
+                let datasetIdsNotInProject = outputDatasetIDs.filter((id) => !projectDatasets.find((d) => d.id === id));
+                // filter out ids with "-"
+                datasetIdsNotInProject = datasetIdsNotInProject.filter((id) => !id.includes("-"));
                 if (datasetIdsNotInProject.length > 0) {
                     const newDatasets = await fetchDatasetsFromService(datasetIdsNotInProject);
                     appDispatch(addDatasetToProject({ projectId: projectId, datasets: newDatasets }));
                 }
             } catch (error) {
-                console.error("Error fetching workflow files: ", error);
+                console.error("Error fetching Dataset files: ", error);
             }
         };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -256,6 +256,63 @@ export function getStatusColor(status?: string) {
     }
 }
 
+export const getOutputDatasetIDsFromExecutionFile = (
+    execution: DatawolfExecutionFile,
+    workflow: DatawolfWorkflowFile
+): string[] => {
+    const outputDatasetIDs: string[] = [];
+    if (!execution || !workflow || !workflow.steps) {
+        return outputDatasetIDs;
+    }
+
+    workflow.steps.forEach((step) => {
+        Object.entries(step.outputs).forEach(([outputKey, outputValue]) => {
+            if (
+                outputValue !== "" &&
+                outputValue !== null &&
+                execution.datasets[outputValue] !== "" &&
+                execution.datasets[outputValue] !== null &&
+                execution.datasets[outputValue] !== "ERROR" &&
+                outputKey !== "stdout"
+            ) {
+                outputDatasetIDs.push(execution.datasets[outputValue]);
+            }
+        });
+    });
+
+    return outputDatasetIDs;
+};
+
+export const getOutputDatasetIDsFromWorkflows = async (workflows: DatawolfWorkflowFile[]): Promise<string[]> => {
+    const outputDatasetIDs: string[] = [];
+    for (const workflow of workflows) {
+        try {
+            const executions = await axios.get(`${config.datawolfApi}/workflows/${workflow.id ?? ""}/executions`, {
+                headers: getHeaders()
+            });
+            if (executions.data) {
+                for (const execution of executions.data) {
+                    outputDatasetIDs.push(...getOutputDatasetIDsFromExecutionFile(execution, workflow));
+                }
+            }
+        } catch (error: any) {
+            // Handle axios-specific errors
+            if (axios.isAxiosError(error)) {
+                console.error(
+                    "Error fetching executions:",
+                    error.response
+                        ? `Error: ${error.response.status} - ${error.response.data}`
+                        : `Network or unknown error: ${error.message}`
+                );
+            }
+
+            // Handle unexpected errors
+            console.error("Unexpected error:", error.message);
+        }
+    }
+    return outputDatasetIDs;
+};
+
 // export function attachExecutionStatusToSteps(execution: DatawolfExecutionFile, workflow: Workflow) {
 //     if (!execution || !workflow || !workflow.steps) {
 //         throw new Error("Invalid execution or workflow data.");


### PR DESCRIPTION
This PR adds the ability to sync result datasets into project datasets. This means, users will now not be able to ever delete any of the result datasets. If they delete it once, it will be added back again on the next sync.

Also, on the side panel, I added visualization tab to view visualizations and its also able to add result datasets to visualizations.