### PR TITLE
fix wrong execution status color and icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Issue where there were discrepancies in reporting wrong status color and icon of an execution [#94](https://github.com/IN-CORE/incore-studio/issues/94)
+
 ## [Alpha-2] - 02-04-2025
 
 ### Added

--- a/src/components/Project/Resource/ExecutionCards.tsx
+++ b/src/components/Project/Resource/ExecutionCards.tsx
@@ -5,6 +5,7 @@ import { Alert, Grid, Link, Box, Stack, Card, CardContent, Chip, Typography, But
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
 import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
+import AccessTimeFilledRoundedIcon from "@mui/icons-material/AccessTimeFilledRounded";
 
 import { useAppDispatch, useAppSelector } from "@app/store/hooks";
 import { parseDateTime } from "@app/utils";
@@ -119,7 +120,13 @@ const ExecutionCardsComponent: React.FC<{
                                                     {execution.title}
                                                 </Link>
                                             </Typography>
-                                            <CheckCircleRoundedIcon sx={{ color: checkColors[chipColor] }} />
+                                            {["FAILED", "ABORTED", "UNKNOWN", "UNDEFINED"].indexOf(status) >= 0 ? (
+                                                <ErrorOutlineRoundedIcon sx={{ color: checkColors[chipColor] }} />
+                                            ) : ["RUNNING", "QUEUED", "WAITING"].indexOf(status) >= 0 ? (
+                                                <AccessTimeFilledRoundedIcon sx={{ color: checkColors[chipColor] }} />
+                                            ) : (
+                                                <CheckCircleRoundedIcon sx={{ color: checkColors[chipColor] }} />
+                                            )}
                                         </Stack>
                                         <Typography level="body-sm">
                                             {execution.description || "Description not provided"}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -259,6 +259,7 @@ export function toSingular(disaster: string): string {
 export const extractStatus = (executionItem: DatawolfExecutionFile | null): string => {
     if (executionItem !== null && executionItem.stepState !== undefined) {
         const statusArr = Object.values(executionItem.stepState);
+        const datasetStatusArr = Object.values(executionItem.datasets);
         // WAITING, QUEUED, RUNNING, FINISHED, ABORTED, FAILED, UNKNOWN
         // if failed or aborted, return failed | aborted
         // else if atleast one running, return running
@@ -273,6 +274,7 @@ export const extractStatus = (executionItem: DatawolfExecutionFile | null): stri
         if (statusArr.indexOf("QUEUED") >= 0) return "QUEUED";
         if (statusArr.indexOf("WAITING") >= 0) return "WAITING";
         if (statusArr.indexOf("UNKNOWN") >= 0) return "UNKNOWN";
+        if (datasetStatusArr.indexOf("ERROR") >= 0) return "FAILED";
         if (statusArr.every((status) => status === "FINISHED")) return "FINISHED";
     }
     return "UNDEFINED";


### PR DESCRIPTION
<img width="489" alt="Screenshot 2025-02-10 at 12 52 07 PM" src="https://github.com/user-attachments/assets/5f830344-5151-4055-8d98-096f1968ca62" />

<img width="1497" alt="Screenshot 2025-02-10 at 12 58 14 PM" src="https://github.com/user-attachments/assets/5cadfb14-bae8-4c66-819e-c51642f47af7" />


I have fixed the look of failed executions. Also, if there is any error in any of the dataset in the execution file, then the execution is marked as failed, even if all the steps report FINISHED.