### PR TITLE
Fix boundingbox and reset to default states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Finalized workflows not being saved first issue. [#204](https://github.com/IN-CORE/incore-studio/issues/204)
 - The items in project dashboard to be default sorted by date in descending order. [#206](https://github.com/IN-CORE/incore-studio/issues/206)
 - Switch from webpack to esbuild and find alternative to serve app with SPA routes [#200](https://github.com/IN-CORE/incore-studio/issues/200)
+- Implement visualization initial view and auto-fitting maximum bounds of layers [#238](https://github.com/IN-CORE/incore-studio/issues/238)
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@mui/material": "6.1.8",
                 "@mui/x-data-grid": "^7.28.3",
                 "@mui/x-tree-view": "^8.7.0",
-                "@ncsa/geo-explorer": "0.1.20",
+                "@ncsa/geo-explorer": "1.0.0",
                 "@reduxjs/toolkit": "^2.2.7",
                 "@rjsf/mui": "^5.24.3",
                 "@rjsf/utils": "^5.24.3",
@@ -3945,9 +3945,9 @@
             "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
         },
         "node_modules/@ncsa/geo-explorer": {
-            "version": "0.1.20",
-            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/0.1.20/55624398d526fcf352b916ac17cdf2ffaa830cde",
-            "integrity": "sha512-yRGmyK4u/G0ipH8jaTthHUPIfWiXWWiY1urxnavb9ld1+8gRBslleiiLH/P80XwZyWWlDCnn/M8XZIiTmFocNQ==",
+            "version": "1.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/1.0.0/313de3c16446cff49115f59e48ad647d8875c336",
+            "integrity": "sha512-Ze+mR/nYHbPXQwi0zQNnv8Dn5Ny19gOQmgneZu3HKdpW+DX7l0L0HrWamjWFv5oXO51rP6BD/VduWdslhhqB+g==",
             "license": "ISC",
             "dependencies": {
                 "@adobe/react-spectrum": "^3.38.1",
@@ -28181,9 +28181,9 @@
             }
         },
         "@ncsa/geo-explorer": {
-            "version": "0.1.20",
-            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/0.1.20/55624398d526fcf352b916ac17cdf2ffaa830cde",
-            "integrity": "sha512-yRGmyK4u/G0ipH8jaTthHUPIfWiXWWiY1urxnavb9ld1+8gRBslleiiLH/P80XwZyWWlDCnn/M8XZIiTmFocNQ==",
+            "version": "1.0.0",
+            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/1.0.0/313de3c16446cff49115f59e48ad647d8875c336",
+            "integrity": "sha512-Ze+mR/nYHbPXQwi0zQNnv8Dn5Ny19gOQmgneZu3HKdpW+DX7l0L0HrWamjWFv5oXO51rP6BD/VduWdslhhqB+g==",
             "requires": {
                 "@adobe/react-spectrum": "^3.38.1",
                 "@emotion/react": "^11.13.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@mui/material": "6.1.8",
                 "@mui/x-data-grid": "^7.28.3",
                 "@mui/x-tree-view": "^8.7.0",
-                "@ncsa/geo-explorer": "1.0.0-beta.14",
+                "@ncsa/geo-explorer": "0.1.20",
                 "@reduxjs/toolkit": "^2.2.7",
                 "@rjsf/mui": "^5.24.3",
                 "@rjsf/utils": "^5.24.3",
@@ -3945,9 +3945,9 @@
             "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg=="
         },
         "node_modules/@ncsa/geo-explorer": {
-            "version": "1.0.0-beta.14",
-            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/1.0.0-beta.14/65364c3f707c5150418eee9125e699d4c4cd5f99",
-            "integrity": "sha512-Pe7Zr5QTSpwKWGl0gOTSiovWlRu+sgiZLh82e7Qst7HXDoh7YRQUaOVfWtEmt9LAcZfyIvwHEiJgRw+XyiTITw==",
+            "version": "0.1.20",
+            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/0.1.20/55624398d526fcf352b916ac17cdf2ffaa830cde",
+            "integrity": "sha512-yRGmyK4u/G0ipH8jaTthHUPIfWiXWWiY1urxnavb9ld1+8gRBslleiiLH/P80XwZyWWlDCnn/M8XZIiTmFocNQ==",
             "license": "ISC",
             "dependencies": {
                 "@adobe/react-spectrum": "^3.38.1",
@@ -28181,9 +28181,9 @@
             }
         },
         "@ncsa/geo-explorer": {
-            "version": "1.0.0-beta.14",
-            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/1.0.0-beta.14/65364c3f707c5150418eee9125e699d4c4cd5f99",
-            "integrity": "sha512-Pe7Zr5QTSpwKWGl0gOTSiovWlRu+sgiZLh82e7Qst7HXDoh7YRQUaOVfWtEmt9LAcZfyIvwHEiJgRw+XyiTITw==",
+            "version": "0.1.20",
+            "resolved": "https://npm.pkg.github.com/download/@ncsa/geo-explorer/0.1.20/55624398d526fcf352b916ac17cdf2ffaa830cde",
+            "integrity": "sha512-yRGmyK4u/G0ipH8jaTthHUPIfWiXWWiY1urxnavb9ld1+8gRBslleiiLH/P80XwZyWWlDCnn/M8XZIiTmFocNQ==",
             "requires": {
                 "@adobe/react-spectrum": "^3.38.1",
                 "@emotion/react": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@mui/joy": "^5.0.0-beta.49",
         "@mui/material": "6.1.8",
         "@mui/x-data-grid": "^7.28.3",
-        "@ncsa/geo-explorer": "1.0.0-beta.15",
+        "@ncsa/geo-explorer": "1.0.0",
         "@mui/x-tree-view": "^8.7.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@rjsf/mui": "^5.24.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@mui/joy": "^5.0.0-beta.49",
         "@mui/material": "6.1.8",
         "@mui/x-data-grid": "^7.28.3",
-        "@ncsa/geo-explorer": "1.0.0-beta.14",
+        "@ncsa/geo-explorer": "1.0.0-beta.15",
         "@mui/x-tree-view": "^8.7.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@rjsf/mui": "^5.24.3",

--- a/src/components/Map/CustomDataInventory/index.tsx
+++ b/src/components/Map/CustomDataInventory/index.tsx
@@ -16,7 +16,7 @@ export const CustomDataInventory = () => {
     return (
         <>
             {!isEditing && (
-                <Button onClick={handleToggle} variant={isEditing ? "contained" : "text"} color="primary">
+                <Button onClick={handleToggle} variant={isEditing ? "contained" : "text"} color="primary" sx={{fontWeight: 800}}>
                     Add New Layers to Visualization
                 </Button>
             )}

--- a/src/components/Map/CustomDataInventory/index.tsx
+++ b/src/components/Map/CustomDataInventory/index.tsx
@@ -16,7 +16,12 @@ export const CustomDataInventory = () => {
     return (
         <>
             {!isEditing && (
-                <Button onClick={handleToggle} variant={isEditing ? "contained" : "text"} color="primary" sx={{fontWeight: 800}}>
+                <Button
+                    onClick={handleToggle}
+                    variant={isEditing ? "contained" : "text"}
+                    color="primary"
+                    sx={{ fontWeight: 800 }}
+                >
                     Add New Layers to Visualization
                 </Button>
             )}

--- a/src/components/Preview/DatasetPreviewModal.tsx
+++ b/src/components/Preview/DatasetPreviewModal.tsx
@@ -200,7 +200,9 @@ const DatasetPreviewModal: React.FC<DatasetDatasetPreviewModalProps> = ({ open, 
                                 temporal_layers: [],
                                 // naive approach to center the map on the visualization bounding box
                                 mapConfig: {
-                                    boundingBox: dataset?.boundingBox
+                                    boundingBox:
+                                        dataset?.boundingBox ??
+                                        (config.DEFAULT_MAP_BOUNDS as [number, number, number, number])
                                 }
                             } as GeoExplorerConfig
                         }
@@ -210,6 +212,7 @@ const DatasetPreviewModal: React.FC<DatasetDatasetPreviewModalProps> = ({ open, 
                             DataInventory: () => null
                         }}
                         onReady={({ store }) => {
+                            // reset to default state
                             store.dispatch(addLayer({ layer_id: dataset.id }));
                             store.dispatch(selectMapLayer({ layer_id: dataset.id }));
                             store.dispatch(setShowLayerSettings({ show: true }));

--- a/src/components/Preview/HazardPreivewModal.tsx
+++ b/src/components/Preview/HazardPreivewModal.tsx
@@ -3,7 +3,14 @@ import React, { useEffect, useState } from "react";
 import { Modal, ModalDialog, ModalClose, Box, Typography } from "@mui/joy";
 
 import config from "@app/app.config";
-import { addLayer, GeoExplorer, GeoExplorerConfig, GeoExplorerProvider } from "@ncsa/geo-explorer";
+import {
+    addLayer,
+    GeoExplorer,
+    GeoExplorerConfig,
+    GeoExplorerProvider,
+    setShowLayerSettings,
+    setSidebarOpen
+} from "@ncsa/geo-explorer";
 import { getHeaders, getOidcUser, mapIncoreDatasetToGeoExplorerDataset } from "@app/utils";
 import axios from "axios";
 import { Dataset as GeoExplorerDataset } from "@ncsa/geo-explorer/dist/types";
@@ -105,6 +112,9 @@ export const HazardPreviewModal: React.FC<HazardPreviewModalProps> = ({ open, on
                         hazardDatasets.forEach((hazardDataset) => {
                             store.dispatch(addLayer({ layer_id: hazardDataset.id }));
                         });
+                        // reset to default state
+                        store.dispatch(setShowLayerSettings({ show: false }));
+                        store.dispatch(setSidebarOpen({ open: true }));
                     }}
                 >
                     <GeoExplorer key={hazardDatasets.map((ds) => ds.id).join(",")} />

--- a/src/components/Project/Resource/VisualizationPage.tsx
+++ b/src/components/Project/Resource/VisualizationPage.tsx
@@ -28,8 +28,11 @@ import config from "@app/app.config";
 import {
     addLayer,
     GeoExplorerConfig,
-    GeoExplorerProvider, selectMapLayer,
-    setLayerStyleName, setShowLayerSettings, setSidebarOpen,
+    GeoExplorerProvider,
+    selectMapLayer,
+    setLayerStyleName,
+    setShowLayerSettings,
+    setSidebarOpen,
     toggleVisibility
 } from "@ncsa/geo-explorer";
 import { getHeaders, getOidcUser, mapIncoreDatasetToGeoExplorerDataset } from "@app/utils";
@@ -68,11 +71,7 @@ const VisualizationPage = (): JSX.Element => {
         }
     }, [id, visualizationPageNumber, deletedVisualizationIds]);
 
-    const onApplyFilterSort = (params: {
-        filters: Record<string, string | number>;
-        sortBy: string;
-        order: string
-    }) => {
+    const onApplyFilterSort = (params: { filters: Record<string, string | number>; sortBy: string; order: string }) => {
         if (id) {
             const { filters, sortBy, order } = params;
 
@@ -255,7 +254,9 @@ const VisualizationPage = (): JSX.Element => {
                                             simple_layers: geoExplorerLayers, // set in the custom layer list component
                                             temporal_layers: [],
                                             mapConfig: {
-                                                boundingBox: visualization?.boundingBox ? visualization?.boundingBox : (config.DEFAULT_MAP_BOUNDS as [number, number, number, number])
+                                                boundingBox:
+                                                    visualization?.boundingBox ??
+                                                    (config.DEFAULT_MAP_BOUNDS as [number, number, number, number])
                                             }
                                         } as GeoExplorerConfig
                                     }
@@ -266,7 +267,7 @@ const VisualizationPage = (): JSX.Element => {
                                     }}
                                     onReady={({ store }) => {
                                         // reset to default state
-                                        store.dispatch(selectMapLayer({ layer_id: null}));
+                                        store.dispatch(selectMapLayer({ layer_id: null }));
                                         store.dispatch(setShowLayerSettings({ show: false }));
                                         store.dispatch(setSidebarOpen({ open: true }));
                                         if (

--- a/src/components/Project/Resource/VisualizationPage.tsx
+++ b/src/components/Project/Resource/VisualizationPage.tsx
@@ -254,7 +254,6 @@ const VisualizationPage = (): JSX.Element => {
                                             ],
                                             simple_layers: geoExplorerLayers, // set in the custom layer list component
                                             temporal_layers: [],
-                                            // naive approach to center the map on the visualization bounding box
                                             mapConfig: {
                                                 boundingBox: visualization?.boundingBox ? visualization?.boundingBox : (config.DEFAULT_MAP_BOUNDS as [number, number, number, number])
                                             }

--- a/src/components/Project/Resource/VisualizationPage.tsx
+++ b/src/components/Project/Resource/VisualizationPage.tsx
@@ -28,8 +28,8 @@ import config from "@app/app.config";
 import {
     addLayer,
     GeoExplorerConfig,
-    GeoExplorerProvider,
-    setLayerStyleName,
+    GeoExplorerProvider, selectMapLayer,
+    setLayerStyleName, setShowLayerSettings, setSidebarOpen,
     toggleVisibility
 } from "@ncsa/geo-explorer";
 import { getHeaders, getOidcUser, mapIncoreDatasetToGeoExplorerDataset } from "@app/utils";
@@ -68,7 +68,11 @@ const VisualizationPage = (): JSX.Element => {
         }
     }, [id, visualizationPageNumber, deletedVisualizationIds]);
 
-    const onApplyFilterSort = (params: { filters: Record<string, string | number>; sortBy: string; order: string }) => {
+    const onApplyFilterSort = (params: {
+        filters: Record<string, string | number>;
+        sortBy: string;
+        order: string
+    }) => {
         if (id) {
             const { filters, sortBy, order } = params;
 
@@ -252,7 +256,7 @@ const VisualizationPage = (): JSX.Element => {
                                             temporal_layers: [],
                                             // naive approach to center the map on the visualization bounding box
                                             mapConfig: {
-                                                boundingBox: visualization?.boundingBox
+                                                boundingBox: visualization?.boundingBox ? visualization?.boundingBox : (config.DEFAULT_MAP_BOUNDS as [number, number, number, number])
                                             }
                                         } as GeoExplorerConfig
                                     }
@@ -262,6 +266,10 @@ const VisualizationPage = (): JSX.Element => {
                                         DataInventory: CustomDataInventory
                                     }}
                                     onReady={({ store }) => {
+                                        // reset to default state
+                                        store.dispatch(selectMapLayer({ layer_id: null}));
+                                        store.dispatch(setShowLayerSettings({ show: false }));
+                                        store.dispatch(setSidebarOpen({ open: true }));
                                         if (
                                             Array.isArray(visualization?.layers) &&
                                             Array.isArray(visualization?.layerOrder)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -965,6 +965,7 @@ export function mapIncoreDatasetToGeoExplorerDataset(dataset: Dataset, ogcServic
             dataset_category: dataset.dataType
         },
         workspace: "incore",
-        default_style_workspace: "studio"
+        default_style_workspace: "studio",
+        boundingBox: dataset.boundingBox
     };
 }


### PR DESCRIPTION
To Test Visualization:
**(This PR will work with geo-explorer beta 15 once published and merged)**

- Initial view should be the "last map view".
- When adding new layers, auto fit the maximum bound of all layers.
- Collapse the side panel; Open data table; Select a layer.  Close visualization modal and reopen, everything should be restored to default view. 
- Fallback to default extent for visualization
- Highlight the "add to vis button"

<img width="1055" height="780" alt="image" src="https://github.com/user-attachments/assets/988868ff-ed8b-4f59-b6cf-8d4d4c918d27" />


@Rashmil-1999 @navarroc 