### PR TITLE
Added bounding box data selection for NSI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Add draw bounding box for NSI dataset tool [#246](https://github.com/IN-CORE/incore-studio/issues/246)
+
+
 ## [1.0.0] - 07-31-2025
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
                 "babel-eslint": "~10.1",
                 "concurrently": "^9.2.0",
                 "core-js": "~3.32",
+                "cross-env": "^10.0.0",
                 "css-loader": "^6.8",
                 "esbuild": "^0.25.5",
                 "esbuild-plugin-copy": "^2.1.1",
@@ -2260,6 +2261,12 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+        },
+        "node_modules/@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "dev": true
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.6",
@@ -14568,6 +14575,23 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/cross-env": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+            "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+            "dev": true,
+            "dependencies": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
+            },
+            "bin": {
+                "cross-env": "dist/bin/cross-env.js",
+                "cross-env-shell": "dist/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/cross-spawn": {
@@ -27250,6 +27274,12 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
         },
+        "@epic-web/invariant": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+            "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+            "dev": true
+        },
         "@esbuild/aix-ppc64": {
             "version": "0.25.6",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
@@ -36483,6 +36513,16 @@
                 "parse-json": "^5.0.0",
                 "path-type": "^4.0.0",
                 "yaml": "^1.10.0"
+            }
+        },
+        "cross-env": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+            "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+            "dev": true,
+            "requires": {
+                "@epic-web/invariant": "^1.0.0",
+                "cross-spawn": "^7.0.6"
             }
         },
         "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
         "@mui/joy": "^5.0.0-beta.49",
         "@mui/material": "6.1.8",
         "@mui/x-data-grid": "^7.28.3",
-        "@ncsa/geo-explorer": "1.0.0",
         "@mui/x-tree-view": "^8.7.0",
+        "@ncsa/geo-explorer": "1.0.0",
         "@reduxjs/toolkit": "^2.2.7",
         "@rjsf/mui": "^5.24.3",
         "@rjsf/utils": "^5.24.3",
@@ -71,6 +71,7 @@
         "babel-eslint": "~10.1",
         "concurrently": "^9.2.0",
         "core-js": "~3.32",
+        "cross-env": "^10.0.0",
         "css-loader": "^6.8",
         "esbuild": "^0.25.5",
         "esbuild-plugin-copy": "^2.1.1",
@@ -103,13 +104,15 @@
         "url-loader": "~4.1"
     },
     "scripts": {
-        "start:dev": "concurrently -k -n BUILD,SERVE -c yellow,cyan \"INCORE_REMOTE_HOSTNAME=https://dev.in-core.org node esbuild.config.mjs --watch\" \"npx serve build -l 3000 -s\"",
+        "start:dev": "concurrently -k -n BUILD,SERVE -c yellow,cyan \"cross-env INCORE_REMOTE_HOSTNAME=https://dev.in-core.org node esbuild.config.mjs --watch\" \"npx serve build -l 3000 -s\"",
         "build": "NODE_ENV=production node esbuild.config.mjs",
         "eject": "react-scripts eject",
-        "lint": "eslint src --color --ext=.tsx,.js",
-        "lint:fix": "eslint --fix src --color --ext=.tsx,.js",
-        "prepare": "husky install",
-        "docs": "typedoc"
+        "test": "react-scripts test",
+        "test:coverage": "react-scripts test --coverage --watchAll=false",
+        "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
+        "lint:fix": "eslint src --ext .ts,.tsx,.js,.jsx --fix",
+        "type-check": "tsc --noEmit",
+        "preview": "npx serve build -l 3000 -s"
     },
     "browserslist": {
         "production": [

--- a/src/components/Map/BoundingBoxDrawer.tsx
+++ b/src/components/Map/BoundingBoxDrawer.tsx
@@ -1,0 +1,282 @@
+import React from "react";
+import maplibregl from "maplibre-gl";
+import { Box, Checkbox, Typography } from "@mui/joy";
+import "maplibre-gl/dist/maplibre-gl.css";
+
+import config from "@app/app.config";
+
+interface BoundingBoxDrawerProps {
+    onBboxSelected: (bbox: [number, number, number, number]) => void;
+    height?: number;
+}
+
+const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, height = 300 }) => {
+    const mapContainerRef = React.useRef<HTMLDivElement>(null);
+    const mapRef = React.useRef<maplibregl.Map>();
+    const [isDrawing, setIsDrawing] = React.useState(false);
+    const [startPoint, setStartPoint] = React.useState<maplibregl.LngLat | null>(null);
+    const [drawModeEnabled, setDrawModeEnabled] = React.useState(false);
+    const [mouseDownTime, setMouseDownTime] = React.useState<number>(0);
+    
+    // Use refs for synchronous access to drawing state
+    const isDrawingRef = React.useRef(false);
+    const startPointRef = React.useRef<maplibregl.LngLat | null>(null);
+
+    // Initialize map
+    React.useEffect(() => {
+        if (mapContainerRef.current && !mapRef.current) {
+            const map = new maplibregl.Map({
+                container: mapContainerRef.current,
+                style: config.basemapStyle,
+                center: [-88.2272, 40.1164], // Champaign, Illinois
+                zoom: 10,
+                maxZoom: 18,
+                minZoom: 2
+            });
+
+                    map.on('load', () => {
+            console.log('BoundingBoxDrawer map loaded');
+            mapRef.current = map;
+        });
+
+            return () => {
+                if (mapRef.current) {
+                    mapRef.current.remove();
+                    mapRef.current = undefined;
+                }
+            };
+        }
+    }, []);
+
+    // Draw bounding box function - matching test implementation exactly
+    const drawBoundingBox = (start: maplibregl.LngLat, end: maplibregl.LngLat) => {
+        const map = mapRef.current;
+        if (!map) {
+            console.log('No map available for drawing');
+            return;
+        }
+        
+        const coordinates = [
+            [start.lng, start.lat],
+            [end.lng, start.lat],
+            [end.lng, end.lat],
+            [start.lng, end.lat],
+            [start.lng, start.lat] // Close the polygon
+        ];
+        
+        // Remove existing bounding box source and layer - matching test IDs
+        if (map.getSource('bounding-box')) {
+            if (map.getLayer('bounding-box-fill')) {
+                map.removeLayer('bounding-box-fill');
+            }
+            if (map.getLayer('bounding-box-layer')) {
+                map.removeLayer('bounding-box-layer');
+            }
+            map.removeSource('bounding-box');
+        }
+        
+        // Add new bounding box
+        map.addSource('bounding-box', {
+            type: 'geojson',
+            data: {
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [coordinates]
+                },
+                properties: {}
+            }
+        });
+        
+        map.addLayer({
+            id: 'bounding-box-layer',
+            type: 'line',
+            source: 'bounding-box',
+            paint: {
+                'line-color': '#ff0000',
+                'line-width': 4,
+                'line-opacity': 1.0
+            }
+        });
+        
+        map.addLayer({
+            id: 'bounding-box-fill',
+            type: 'fill',
+            source: 'bounding-box',
+            paint: {
+                'fill-color': '#ff0000',
+                'fill-opacity': 0.1
+            }
+        });
+    };
+
+    const clearBoundingBox = () => {
+        const map = mapRef.current;
+        if (!map) return;
+
+        if (map.getSource('bounding-box')) {
+            map.removeLayer('bounding-box-fill');
+            map.removeLayer('bounding-box-layer');
+            map.removeSource('bounding-box');
+        }
+    };
+
+    const finalizeBoundingBox = (start: maplibregl.LngLat, end: maplibregl.LngLat) => {
+        const minLng = Math.min(start.lng, end.lng);
+        const minLat = Math.min(start.lat, end.lat);
+        const maxLng = Math.max(start.lng, end.lng);
+        const maxLat = Math.max(start.lat, end.lat);
+        
+        onBboxSelected([minLng, minLat, maxLng, maxLat]);
+    };
+
+    // Event handlers - matching test implementation exactly
+    const onMouseDown = (e: maplibregl.MapMouseEvent) => {
+        if (!drawModeEnabled) {
+            return;
+        }
+        
+        setIsDrawing(true);
+        setStartPoint(e.lngLat);
+        setMouseDownTime(Date.now());
+        
+        // Update refs synchronously
+        isDrawingRef.current = true;
+        startPointRef.current = e.lngLat;
+    };
+
+    const onMouseMove = (e: maplibregl.MapMouseEvent) => {
+        // Use refs for synchronous access
+        if (!isDrawingRef.current || !startPointRef.current) {
+            return;
+        }
+        
+        drawBoundingBox(startPointRef.current, e.lngLat);
+    };
+
+    const onMouseUp = (e: maplibregl.MapMouseEvent) => {
+        const timeSinceMouseDown = Date.now() - mouseDownTime;
+        
+        if (!isDrawingRef.current || !startPointRef.current) {
+            return;
+        }
+        
+        // Ignore mouse up if it happens too quickly after mouse down (less than 50ms)
+        if (timeSinceMouseDown < 50) {
+            return;
+        }
+        
+        setIsDrawing(false);
+        const endPoint = e.lngLat;
+        
+        // Only create bounding box if there's meaningful distance
+        const distance = Math.sqrt(
+            Math.pow(endPoint.lng - startPointRef.current.lng, 2) + 
+            Math.pow(endPoint.lat - startPointRef.current.lat, 2)
+        );
+        
+        if (distance > 0.001) { // Minimum distance threshold
+            finalizeBoundingBox(startPointRef.current, endPoint);
+        } else {
+            clearBoundingBox();
+        }
+        
+        setStartPoint(null);
+        
+        // Reset refs
+        isDrawingRef.current = false;
+        startPointRef.current = null;
+    };
+
+    // Enable/disable drawing - matching test implementation
+    const enableBoundingBoxDrawing = () => {
+        const map = mapRef.current;
+        if (!map) {
+            console.log('No map available for enabling drawing');
+            return;
+        }
+
+        map.getCanvas().style.cursor = 'crosshair';
+        
+        // Disable ALL map interactions to prevent any interference
+        map.dragPan.disable();
+        map.dragRotate.disable();
+        map.scrollZoom.disable();
+        map.boxZoom.disable();
+        map.keyboard.disable();
+        map.doubleClickZoom.disable();
+        
+        // Add event listeners for drawing
+        map.on('mousedown', onMouseDown);
+        map.on('mousemove', onMouseMove);
+        map.on('mouseup', onMouseUp);
+    };
+
+    const disableBoundingBoxDrawing = () => {
+        const map = mapRef.current;
+        if (!map) return;
+
+        map.getCanvas().style.cursor = '';
+        
+        // Re-enable ALL map interactions
+        map.dragPan.enable();
+        map.dragRotate.enable();
+        map.scrollZoom.enable();
+        map.boxZoom.enable();
+        map.keyboard.enable();
+        map.doubleClickZoom.enable();
+        
+        // Remove event listeners
+        map.off('mousedown', onMouseDown);
+        map.off('mousemove', onMouseMove);
+        map.off('mouseup', onMouseUp);
+        
+        // Clear any existing bounding box
+        clearBoundingBox();
+    };
+
+    // Handle draw mode toggle
+    React.useEffect(() => {
+        if (drawModeEnabled) {
+            enableBoundingBoxDrawing();
+        } else {
+            disableBoundingBoxDrawing();
+        }
+    }, [drawModeEnabled]);
+
+    return (
+        <Box sx={{ position: "relative" }}>
+            <Box 
+                ref={mapContainerRef} 
+                sx={{ 
+                    height: height, 
+                    border: "1px solid #ddd",
+                    position: "relative"
+                }} 
+            />
+            <Box sx={{ 
+                position: "absolute", 
+                top: 8, 
+                right: 8, 
+                zIndex: 2, 
+                backgroundColor: "#fff", 
+                p: 1, 
+                border: "1px solid #ddd", 
+                borderRadius: 4 
+            }}>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Checkbox
+                        size="sm"
+                        checked={drawModeEnabled}
+                        onChange={(e) => setDrawModeEnabled(e.target.checked)}
+                    />
+                    <Typography level="body-sm" sx={{ ml: 1 }}>
+                        Draw Bounding Box
+                    </Typography>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default BoundingBoxDrawer; 

--- a/src/components/Map/BoundingBoxDrawer.tsx
+++ b/src/components/Map/BoundingBoxDrawer.tsx
@@ -17,7 +17,7 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     const [startPoint, setStartPoint] = React.useState<maplibregl.LngLat | null>(null);
     const [drawModeEnabled, setDrawModeEnabled] = React.useState(false);
     const [mouseDownTime, setMouseDownTime] = React.useState<number>(0);
-    
+
     // Use refs for synchronous access to drawing state
     const isDrawingRef = React.useRef(false);
     const startPointRef = React.useRef<maplibregl.LngLat | null>(null);
@@ -34,10 +34,10 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
                 minZoom: 2
             });
 
-                    map.on('load', () => {
-            console.log('BoundingBoxDrawer map loaded');
-            mapRef.current = map;
-        });
+            map.on("load", () => {
+                console.log("BoundingBoxDrawer map loaded");
+                mapRef.current = map;
+            });
 
             return () => {
                 if (mapRef.current) {
@@ -52,10 +52,10 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     const drawBoundingBox = (start: maplibregl.LngLat, end: maplibregl.LngLat) => {
         const map = mapRef.current;
         if (!map) {
-            console.log('No map available for drawing');
+            console.log("No map available for drawing");
             return;
         }
-        
+
         const coordinates = [
             [start.lng, start.lat],
             [end.lng, start.lat],
@@ -63,49 +63,49 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             [start.lng, end.lat],
             [start.lng, start.lat] // Close the polygon
         ];
-        
+
         // Remove existing bounding box source and layer - matching test IDs
-        if (map.getSource('bounding-box')) {
-            if (map.getLayer('bounding-box-fill')) {
-                map.removeLayer('bounding-box-fill');
+        if (map.getSource("bounding-box")) {
+            if (map.getLayer("bounding-box-fill")) {
+                map.removeLayer("bounding-box-fill");
             }
-            if (map.getLayer('bounding-box-layer')) {
-                map.removeLayer('bounding-box-layer');
+            if (map.getLayer("bounding-box-layer")) {
+                map.removeLayer("bounding-box-layer");
             }
-            map.removeSource('bounding-box');
+            map.removeSource("bounding-box");
         }
-        
+
         // Add new bounding box
-        map.addSource('bounding-box', {
-            type: 'geojson',
+        map.addSource("bounding-box", {
+            type: "geojson",
             data: {
-                type: 'Feature',
+                type: "Feature",
                 geometry: {
-                    type: 'Polygon',
+                    type: "Polygon",
                     coordinates: [coordinates]
                 },
                 properties: {}
             }
         });
-        
+
         map.addLayer({
-            id: 'bounding-box-layer',
-            type: 'line',
-            source: 'bounding-box',
+            id: "bounding-box-layer",
+            type: "line",
+            source: "bounding-box",
             paint: {
-                'line-color': '#ff0000',
-                'line-width': 4,
-                'line-opacity': 1.0
+                "line-color": "#ff0000",
+                "line-width": 4,
+                "line-opacity": 1.0
             }
         });
-        
+
         map.addLayer({
-            id: 'bounding-box-fill',
-            type: 'fill',
-            source: 'bounding-box',
+            id: "bounding-box-fill",
+            type: "fill",
+            source: "bounding-box",
             paint: {
-                'fill-color': '#ff0000',
-                'fill-opacity': 0.1
+                "fill-color": "#ff0000",
+                "fill-opacity": 0.1
             }
         });
     };
@@ -114,10 +114,10 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         const map = mapRef.current;
         if (!map) return;
 
-        if (map.getSource('bounding-box')) {
-            map.removeLayer('bounding-box-fill');
-            map.removeLayer('bounding-box-layer');
-            map.removeSource('bounding-box');
+        if (map.getSource("bounding-box")) {
+            map.removeLayer("bounding-box-fill");
+            map.removeLayer("bounding-box-layer");
+            map.removeSource("bounding-box");
         }
     };
 
@@ -126,7 +126,7 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         const minLat = Math.min(start.lat, end.lat);
         const maxLng = Math.max(start.lng, end.lng);
         const maxLat = Math.max(start.lat, end.lat);
-        
+
         onBboxSelected([minLng, minLat, maxLng, maxLat]);
     };
 
@@ -135,17 +135,17 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         if (!drawModeEnabled) {
             return;
         }
-        
-        console.log('Mouse down - drawModeEnabled:', drawModeEnabled, 'isDrawing:', isDrawingRef.current);
-        
+
+        console.log("Mouse down - drawModeEnabled:", drawModeEnabled, "isDrawing:", isDrawingRef.current);
+
         // Prevent default map behavior
         e.preventDefault();
         e.originalEvent.stopPropagation();
-        
+
         setIsDrawing(true);
         setStartPoint(e.lngLat);
         setMouseDownTime(Date.now());
-        
+
         // Update refs synchronously
         isDrawingRef.current = true;
         startPointRef.current = e.lngLat;
@@ -156,29 +156,29 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         if (!isDrawingRef.current || !startPointRef.current) {
             return;
         }
-        
+
         // Prevent default map behavior
         e.preventDefault();
         e.originalEvent.stopPropagation();
-        
-        console.log('Mouse move - drawing bounding box');
+
+        console.log("Mouse move - drawing bounding box");
         drawBoundingBox(startPointRef.current, e.lngLat);
     };
 
     const onMouseUp = (e: maplibregl.MapMouseEvent) => {
         const timeSinceMouseDown = Date.now() - mouseDownTime;
-        
+
         if (!isDrawingRef.current || !startPointRef.current) {
             return;
         }
-        
+
         // Prevent default map behavior
         e.preventDefault();
         e.originalEvent.stopPropagation();
-        
+
         // Ignore mouse up if it happens too quickly after mouse down (less than 50ms)
         if (timeSinceMouseDown < 50) {
-            console.log('Mouse up too quick, ignoring');
+            console.log("Mouse up too quick, ignoring");
             // Reset refs even if ignored
             isDrawingRef.current = false;
             startPointRef.current = null;
@@ -186,25 +186,26 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             setStartPoint(null);
             return;
         }
-        
-        console.log('Mouse up - finalizing bounding box');
+
+        console.log("Mouse up - finalizing bounding box");
         setIsDrawing(false);
         const endPoint = e.lngLat;
-        
+
         // Only create bounding box if there's meaningful distance
         const distance = Math.sqrt(
-            Math.pow(endPoint.lng - startPointRef.current.lng, 2) + 
-            Math.pow(endPoint.lat - startPointRef.current.lat, 2)
+            Math.pow(endPoint.lng - startPointRef.current.lng, 2) +
+                Math.pow(endPoint.lat - startPointRef.current.lat, 2)
         );
-        
-        if (distance > 0.001) { // Minimum distance threshold
+
+        if (distance > 0.001) {
+            // Minimum distance threshold
             finalizeBoundingBox(startPointRef.current, endPoint);
         } else {
             clearBoundingBox();
         }
-        
+
         setStartPoint(null);
-        
+
         // Reset refs
         isDrawingRef.current = false;
         startPointRef.current = null;
@@ -214,13 +215,13 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     const enableBoundingBoxDrawing = () => {
         const map = mapRef.current;
         if (!map) {
-            console.log('No map available for enabling drawing');
+            console.log("No map available for enabling drawing");
             return;
         }
 
-        console.log('Enabling bounding box drawing mode');
-        map.getCanvas().style.cursor = 'crosshair';
-        
+        console.log("Enabling bounding box drawing mode");
+        map.getCanvas().style.cursor = "crosshair";
+
         // Disable ALL map interactions to prevent any interference
         map.dragPan.disable();
         map.dragRotate.disable();
@@ -228,22 +229,22 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         map.boxZoom.disable();
         map.keyboard.disable();
         map.doubleClickZoom.disable();
-        
+
         // Add event listeners for drawing
-        map.on('mousedown', onMouseDown);
-        map.on('mousemove', onMouseMove);
-        map.on('mouseup', onMouseUp);
-        
-        console.log('Drawing mode enabled - map interactions disabled, event listeners added');
+        map.on("mousedown", onMouseDown);
+        map.on("mousemove", onMouseMove);
+        map.on("mouseup", onMouseUp);
+
+        console.log("Drawing mode enabled - map interactions disabled, event listeners added");
     };
 
     const disableBoundingBoxDrawing = () => {
         const map = mapRef.current;
         if (!map) return;
 
-        console.log('Disabling bounding box drawing mode');
-        map.getCanvas().style.cursor = '';
-        
+        console.log("Disabling bounding box drawing mode");
+        map.getCanvas().style.cursor = "";
+
         // Re-enable ALL map interactions
         map.dragPan.enable();
         map.dragRotate.enable();
@@ -251,55 +252,57 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         map.boxZoom.enable();
         map.keyboard.enable();
         map.doubleClickZoom.enable();
-        
+
         // Remove event listeners
-        map.off('mousedown', onMouseDown);
-        map.off('mousemove', onMouseMove);
-        map.off('mouseup', onMouseUp);
-        
+        map.off("mousedown", onMouseDown);
+        map.off("mousemove", onMouseMove);
+        map.off("mouseup", onMouseUp);
+
         // Clear any existing bounding box
         clearBoundingBox();
-        
-        console.log('Drawing mode disabled - map interactions enabled, event listeners removed');
+
+        console.log("Drawing mode disabled - map interactions enabled, event listeners removed");
     };
 
     // Handle draw mode toggle
     React.useEffect(() => {
-        console.log('Draw mode effect triggered - drawModeEnabled:', drawModeEnabled);
-        
+        console.log("Draw mode effect triggered - drawModeEnabled:", drawModeEnabled);
+
         if (drawModeEnabled) {
             enableBoundingBoxDrawing();
         } else {
             disableBoundingBoxDrawing();
         }
-        
+
         // Cleanup function to ensure proper cleanup when component unmounts or drawModeEnabled changes
         return () => {
-            console.log('Cleaning up drawing mode');
+            console.log("Cleaning up drawing mode");
             disableBoundingBoxDrawing();
         };
     }, [drawModeEnabled]);
 
     return (
         <Box sx={{ position: "relative" }}>
-            <Box 
-                ref={mapContainerRef} 
-                sx={{ 
-                    height: height, 
+            <Box
+                ref={mapContainerRef}
+                sx={{
+                    height: height,
                     border: "1px solid #ddd",
                     position: "relative"
-                }} 
+                }}
             />
-            <Box sx={{ 
-                position: "absolute", 
-                top: 8, 
-                right: 8, 
-                zIndex: 2, 
-                backgroundColor: "#fff", 
-                p: 1, 
-                border: "1px solid #ddd", 
-                borderRadius: 4 
-            }}>
+            <Box
+                sx={{
+                    position: "absolute",
+                    top: 12,
+                    right: 8,
+                    zIndex: 2,
+                    backgroundColor: "#fff",
+                    p: 1,
+                    border: "1px solid #ddd",
+                    borderRadius: 4
+                }}
+            >
                 <Box sx={{ display: "flex", alignItems: "center" }}>
                     <Checkbox
                         size="sm"
@@ -315,4 +318,4 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     );
 };
 
-export default BoundingBoxDrawer; 
+export default BoundingBoxDrawer;

--- a/src/components/Map/BoundingBoxDrawer.tsx
+++ b/src/components/Map/BoundingBoxDrawer.tsx
@@ -13,8 +13,6 @@ interface BoundingBoxDrawerProps {
 const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, height = 300 }) => {
     const mapContainerRef = React.useRef<HTMLDivElement>(null);
     const mapRef = React.useRef<maplibregl.Map>();
-    const [isDrawing, setIsDrawing] = React.useState(false);
-    const [startPoint, setStartPoint] = React.useState<maplibregl.LngLat | null>(null);
     const [drawModeEnabled, setDrawModeEnabled] = React.useState(false);
     const [mouseDownTime, setMouseDownTime] = React.useState<number>(0);
 
@@ -35,7 +33,6 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             });
 
             map.on("load", () => {
-                console.log("BoundingBoxDrawer map loaded");
                 mapRef.current = map;
             });
 
@@ -52,7 +49,6 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     const drawBoundingBox = (start: maplibregl.LngLat, end: maplibregl.LngLat) => {
         const map = mapRef.current;
         if (!map) {
-            console.log("No map available for drawing");
             return;
         }
 
@@ -136,14 +132,10 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             return;
         }
 
-        console.log("Mouse down - drawModeEnabled:", drawModeEnabled, "isDrawing:", isDrawingRef.current);
-
         // Prevent default map behavior
         e.preventDefault();
         e.originalEvent.stopPropagation();
 
-        setIsDrawing(true);
-        setStartPoint(e.lngLat);
         setMouseDownTime(Date.now());
 
         // Update refs synchronously
@@ -161,7 +153,6 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         e.preventDefault();
         e.originalEvent.stopPropagation();
 
-        console.log("Mouse move - drawing bounding box");
         drawBoundingBox(startPointRef.current, e.lngLat);
     };
 
@@ -178,17 +169,12 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
 
         // Ignore mouse up if it happens too quickly after mouse down (less than 50ms)
         if (timeSinceMouseDown < 50) {
-            console.log("Mouse up too quick, ignoring");
             // Reset refs even if ignored
             isDrawingRef.current = false;
             startPointRef.current = null;
-            setIsDrawing(false);
-            setStartPoint(null);
             return;
         }
 
-        console.log("Mouse up - finalizing bounding box");
-        setIsDrawing(false);
         const endPoint = e.lngLat;
 
         // Only create bounding box if there's meaningful distance
@@ -204,8 +190,6 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             clearBoundingBox();
         }
 
-        setStartPoint(null);
-
         // Reset refs
         isDrawingRef.current = false;
         startPointRef.current = null;
@@ -215,11 +199,9 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
     const enableBoundingBoxDrawing = () => {
         const map = mapRef.current;
         if (!map) {
-            console.log("No map available for enabling drawing");
             return;
         }
 
-        console.log("Enabling bounding box drawing mode");
         map.getCanvas().style.cursor = "crosshair";
 
         // Disable ALL map interactions to prevent any interference
@@ -234,15 +216,12 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         map.on("mousedown", onMouseDown);
         map.on("mousemove", onMouseMove);
         map.on("mouseup", onMouseUp);
-
-        console.log("Drawing mode enabled - map interactions disabled, event listeners added");
     };
 
     const disableBoundingBoxDrawing = () => {
         const map = mapRef.current;
         if (!map) return;
 
-        console.log("Disabling bounding box drawing mode");
         map.getCanvas().style.cursor = "";
 
         // Re-enable ALL map interactions
@@ -260,14 +239,10 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
 
         // Clear any existing bounding box
         clearBoundingBox();
-
-        console.log("Drawing mode disabled - map interactions enabled, event listeners removed");
     };
 
     // Handle draw mode toggle
     React.useEffect(() => {
-        console.log("Draw mode effect triggered - drawModeEnabled:", drawModeEnabled);
-
         if (drawModeEnabled) {
             enableBoundingBoxDrawing();
         } else {
@@ -276,7 +251,6 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
 
         // Cleanup function to ensure proper cleanup when component unmounts or drawModeEnabled changes
         return () => {
-            console.log("Cleaning up drawing mode");
             disableBoundingBoxDrawing();
         };
     }, [drawModeEnabled]);

--- a/src/components/Map/BoundingBoxDrawer.tsx
+++ b/src/components/Map/BoundingBoxDrawer.tsx
@@ -28,8 +28,8 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             const map = new maplibregl.Map({
                 container: mapContainerRef.current,
                 style: config.basemapStyle,
-                center: [-88.2272, 40.1164], // Champaign, Illinois
-                zoom: 10,
+                center: [-88.9861, 40.3495], // Center of Illinois
+                zoom: 5, // Zoom out to show Illinois and surrounding states
                 maxZoom: 18,
                 minZoom: 2
             });
@@ -136,6 +136,12 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             return;
         }
         
+        console.log('Mouse down - drawModeEnabled:', drawModeEnabled, 'isDrawing:', isDrawingRef.current);
+        
+        // Prevent default map behavior
+        e.preventDefault();
+        e.originalEvent.stopPropagation();
+        
         setIsDrawing(true);
         setStartPoint(e.lngLat);
         setMouseDownTime(Date.now());
@@ -151,6 +157,11 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             return;
         }
         
+        // Prevent default map behavior
+        e.preventDefault();
+        e.originalEvent.stopPropagation();
+        
+        console.log('Mouse move - drawing bounding box');
         drawBoundingBox(startPointRef.current, e.lngLat);
     };
 
@@ -161,11 +172,22 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             return;
         }
         
+        // Prevent default map behavior
+        e.preventDefault();
+        e.originalEvent.stopPropagation();
+        
         // Ignore mouse up if it happens too quickly after mouse down (less than 50ms)
         if (timeSinceMouseDown < 50) {
+            console.log('Mouse up too quick, ignoring');
+            // Reset refs even if ignored
+            isDrawingRef.current = false;
+            startPointRef.current = null;
+            setIsDrawing(false);
+            setStartPoint(null);
             return;
         }
         
+        console.log('Mouse up - finalizing bounding box');
         setIsDrawing(false);
         const endPoint = e.lngLat;
         
@@ -196,6 +218,7 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
             return;
         }
 
+        console.log('Enabling bounding box drawing mode');
         map.getCanvas().style.cursor = 'crosshair';
         
         // Disable ALL map interactions to prevent any interference
@@ -210,12 +233,15 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         map.on('mousedown', onMouseDown);
         map.on('mousemove', onMouseMove);
         map.on('mouseup', onMouseUp);
+        
+        console.log('Drawing mode enabled - map interactions disabled, event listeners added');
     };
 
     const disableBoundingBoxDrawing = () => {
         const map = mapRef.current;
         if (!map) return;
 
+        console.log('Disabling bounding box drawing mode');
         map.getCanvas().style.cursor = '';
         
         // Re-enable ALL map interactions
@@ -233,15 +259,25 @@ const BoundingBoxDrawer: React.FC<BoundingBoxDrawerProps> = ({ onBboxSelected, h
         
         // Clear any existing bounding box
         clearBoundingBox();
+        
+        console.log('Drawing mode disabled - map interactions enabled, event listeners removed');
     };
 
     // Handle draw mode toggle
     React.useEffect(() => {
+        console.log('Draw mode effect triggered - drawModeEnabled:', drawModeEnabled);
+        
         if (drawModeEnabled) {
             enableBoundingBoxDrawing();
         } else {
             disableBoundingBoxDrawing();
         }
+        
+        // Cleanup function to ensure proper cleanup when component unmounts or drawModeEnabled changes
+        return () => {
+            console.log('Cleaning up drawing mode');
+            disableBoundingBoxDrawing();
+        };
     }, [drawModeEnabled]);
 
     return (

--- a/src/components/Map/SimpleMap.tsx
+++ b/src/components/Map/SimpleMap.tsx
@@ -18,6 +18,7 @@ interface Props {
     attribution?: boolean;
     navigation?: boolean;
     onLoad: (map: maplibregl.Map) => void;
+    showLayerSwitcher?: boolean;
 }
 
 const SimpleMap = ({
@@ -28,7 +29,8 @@ const SimpleMap = ({
     init_zoom,
     attribution,
     navigation,
-    onLoad
+    onLoad,
+    showLayerSwitcher = true
 }: Props): JSX.Element => {
     const mapContainerRef = React.useRef<HTMLDivElement>(null);
     const mapRef = React.useRef<maplibregl.Map>();
@@ -254,37 +256,39 @@ const SimpleMap = ({
             ) : null}
 
             {/* Layer Switcher UI */}
-            <Box
-                sx={{
-                    position: "absolute",
-                    top: 10,
-                    left: 10,
-                    width: "fit-content",
-                    zIndex: 1,
-                    padding: 2,
-                    backgroundColor: "#fff",
-                    border: "0.5px solid #999"
-                }}
-            >
-                <Accordion variant="plain" defaultExpanded>
-                    <AccordionSummary>
-                        <Typography level="body-md">Layers</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails sx={{ marginTop: "0.5em" }}>
-                        {layers.map((layer) => (
-                            <Box key={layer.layerId} sx={{ display: "flex", alignItems: "center", mb: 1 }}>
-                                <Checkbox
-                                    checked={!!activeLayers[`incore-${layer.layerId}`]}
-                                    onChange={() => toggleLayer(`incore-${layer.layerId}`)}
-                                    size="sm"
-                                    sx={{ mr: 1 }}
-                                />
-                                <Typography>{`${layer.workspace}:${layer.layerId}`}</Typography>
-                            </Box>
-                        ))}
-                    </AccordionDetails>
-                </Accordion>
-            </Box>
+            {showLayerSwitcher && layers.length > 0 ? (
+                <Box
+                    sx={{
+                        position: "absolute",
+                        top: 10,
+                        left: 10,
+                        width: "fit-content",
+                        zIndex: 1,
+                        padding: 2,
+                        backgroundColor: "#fff",
+                        border: "0.5px solid #999"
+                    }}
+                >
+                    <Accordion variant="plain" defaultExpanded>
+                        <AccordionSummary>
+                            <Typography level="body-md">Layers</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails sx={{ marginTop: "0.5em" }}>
+                            {layers.map((layer) => (
+                                <Box key={layer.layerId} sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+                                    <Checkbox
+                                        checked={!!activeLayers[`incore-${layer.layerId}`]}
+                                        onChange={() => toggleLayer(`incore-${layer.layerId}`)}
+                                        size="sm"
+                                        sx={{ mr: 1 }}
+                                    />
+                                    <Typography>{`${layer.workspace}:${layer.layerId}`}</Typography>
+                                </Box>
+                            ))}
+                        </AccordionDetails>
+                    </Accordion>
+                </Box>
+            ) : null}
         </Box>
     );
 };

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -14,12 +14,15 @@ import {
     ModalDialog,
     ModalClose,
     Textarea,
-    Typography
+    Typography,
+    Select,
+    Option
 } from "@mui/joy";
 
 import fipsData from "@app/components/Project/Resource/fips.json";
 import { getHeaders } from "@app/utils";
 import config from "@app/app.config";
+import BoundingBoxDrawer from "@app/components/Map/BoundingBoxDrawer";
 
 // Define the shape of a FIPS record
 interface FipsEntry {
@@ -45,6 +48,11 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
     const [title, setTitle] = React.useState<string>("");
     const [description, setDescription] = React.useState<string>("");
     const [touched, setTouched] = React.useState(false);
+    const [selectionMethod, setSelectionMethod] = React.useState<"fips" | "bbox">("fips");
+
+    // BBox state
+    const [bbox, setBbox] = React.useState<[number, number, number, number] | null>(null);
+    const [confirmOpen, setConfirmOpen] = React.useState(false);
 
     const allowedFipsData = (fipsData as FipsEntry[]).filter((entry) => allowedStates.includes(entry.state));
 
@@ -79,11 +87,12 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
         return () => clearTimeout(handler);
     }, [inputValue]);
 
+    // Submit handler
     const handleApply = () => {
         const payload = {
             title: title,
             description: description,
-            hazardType: "earthquake", // Default to flood if not selected
+            hazardType: "earthquake",
             fips_list: selectedFips ? [selectedFips] : []
         };
 
@@ -91,147 +100,277 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
             axios.post(`${config.toolsApi}/bldg-inventory?projectid=${projectId}`, payload, {
                 headers: getHeaders()
             });
-            handleSnackbar?.("success"); // Notify parent component
+            handleSnackbar?.("success");
         } catch (error) {
-            handleSnackbar?.("failure"); // Notify parent component of error
+            handleSnackbar?.("failure");
             console.error("Error creating building inventory dataset:", error);
         }
-        onClose(); // Close the modal after submission
+        onClose();
     };
 
+    // Handle bbox selection from BoundingBoxDrawer
+    const handleBboxSelected = (selectedBbox: [number, number, number, number]) => {
+        console.log("NSI Modal: Received bbox", selectedBbox);
+        setBbox(selectedBbox);
+        setConfirmOpen(true);
+    };
+
+    // Clear bbox when switching to FIPS
+    React.useEffect(() => {
+        if (selectionMethod === "fips") {
+            setBbox(null);
+            setConfirmOpen(false);
+        }
+    }, [selectionMethod]);
+
     return (
-        <Modal open={open} onClose={onClose}>
-            <ModalDialog variant="outlined" sx={{ maxWidth: "90vw" }}>
-                <ModalClose sx={{ zIndex: 20 }} />
-                <Box sx={{ padding: 1 }}>
-                    <Typography
-                        id="create-nsi-dataset-dialog-title"
-                        component="h2"
-                        fontSize="lg"
-                        fontWeight="bold"
-                        sx={{ mb: 1 }}
-                    >
-                        Generate Building Inventory Dataset
-                    </Typography>
-                    <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
-                        This tool will generate an IN-CORE building inventory dataset based on NSI (National Structure
-                        Inventory) for a FIPS code. The dataset is configured to work with fragility curves for IN-CORE.
-                        Currently, the tool supports the following hazards: Earthquake, Tsunami, Flood, Hurricane wind.
-                    </Typography>
-                    <form
-                        onSubmit={(e) => {
-                            e.preventDefault();
-                            handleApply();
-                            onClose();
-                        }}
-                    >
-                        <FormControl required sx={{ mb: 2 }}>
-                            <FormLabel>Title</FormLabel>
-                            <Input
-                                variant="outlined"
-                                required
-                                placeholder="Dataset Title"
-                                value={title}
-                                onChange={(e) => {
-                                    if (/^[A-Za-z0-9 _-]*$/.test(e.target.value)) {
-                                        setTitle(e.target.value);
-                                    }
-                                }}
-                            />
-                            <FormHelperText sx={{ mb: 1 }}>Enter a title for the dataset.</FormHelperText>
-                            <Typography level="body-xs" color="neutral">
-                                Only Alpha-numeric characters, Underscores and Hyphens are allowed.
-                            </Typography>
-                        </FormControl>
-
-                        <FormControl required sx={{ mb: 2 }}>
-                            <FormLabel>Description</FormLabel>
-                            <Textarea
-                                placeholder="Enter a description for the dataset"
-                                value={description}
-                                minRows={3}
-                                maxRows={5}
-                                onChange={(e) => {
-                                    if (/^[A-Za-z0-9 _-]*$/.test(e.target.value)) {
-                                        setDescription(e.target.value);
-                                    }
-                                }}
-                            />
-                            <FormHelperText sx={{ mb: 1 }}>Provide a brief description of the dataset.</FormHelperText>
-                            <Typography level="body-xs" color="neutral">
-                                Only Alpha-numeric characters, Underscores and Hyphens are allowed.
-                            </Typography>
-                        </FormControl>
-
-                        <FormControl error={showError} sx={{ mb: 2 }}>
-                            <FormLabel required>FIPS Lookup</FormLabel>
-                            <Autocomplete
-                                freeSolo
-                                placeholder="Search by FIPS, state, or county"
-                                // Exclude already selected entries
-                                options={filteredOptions}
-                                getOptionLabel={(option) =>
-                                    typeof option === "string"
-                                        ? option
-                                        : `${option.fips} - ${option.county}, ${option.state}`
-                                }
-                                onBlur={handleBlur}
-                                value={selectedFips}
-                                onChange={(_e, newValue) =>
-                                    setSelectedFips(
-                                        typeof newValue === "object" && newValue !== null && "fips" in newValue
-                                            ? (newValue as FipsEntry).fips
-                                            : typeof newValue === "string"
-                                              ? newValue
-                                              : null
-                                    )
-                                }
-                                inputValue={inputValue}
-                                onInputChange={(_e, newValue) => setInputValue(newValue)}
-                                renderTags={(value, getTagProps) =>
-                                    value.map((option, index) => (
-                                        <Chip {...getTagProps({ index })} variant="soft" size="sm">
-                                            {`${option.fips} - ${option.county}`}
-                                        </Chip>
-                                    ))
-                                }
-                            />
-                            <FormHelperText sx={{ mb: 1 }}>
-                                Search by FIPS code, state, or county name. (Only California, Oregon, and Tennessee are
-                                available.)
-                            </FormHelperText>
-                            {showError && (
-                                <Typography fontSize="sm" color="danger">
-                                    Please select a FIPS entry.
+        <>
+            <Modal open={open} onClose={onClose}>
+                <ModalDialog 
+                    variant="outlined" 
+                    sx={{ 
+                        maxWidth: selectionMethod === "bbox" ? "90vw" : "60vw",
+                        width: selectionMethod === "bbox" ? "90vw" : "60vw",
+                        display: "flex",
+                        flexDirection: "row",
+                        gap: 2,
+                        alignItems: "flex-start"
+                    }}
+                >
+                    <ModalClose sx={{ zIndex: 20 }} />
+                    
+                    {/* Left side - Form content */}
+                    <Box sx={{ 
+                        padding: 1, 
+                        flex: "1 1 400px",
+                        minWidth: "400px"
+                    }}>
+                        <Typography
+                            id="create-nsi-dataset-dialog-title"
+                            component="h2"
+                            fontSize="lg"
+                            fontWeight="bold"
+                            sx={{ mb: 1 }}
+                        >
+                            Generate Building Inventory Dataset
+                        </Typography>
+                        <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
+                            This tool will generate an IN-CORE building inventory dataset based on NSI (National Structure
+                            Inventory) for a FIPS code. The dataset is configured to work with fragility curves for IN-CORE.
+                            Currently, the tool supports the following hazards: Earthquake, Tsunami, Flood, Hurricane wind.
+                        </Typography>
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                handleApply();
+                                onClose();
+                            }}
+                        >
+                            <FormControl required sx={{ mb: 2 }}>
+                                <FormLabel>Title</FormLabel>
+                                <Input
+                                    variant="outlined"
+                                    required
+                                    placeholder="Dataset Title"
+                                    value={title}
+                                    onChange={(e) => {
+                                        if (/^[A-Za-z0-9 _-]*$/.test(e.target.value)) {
+                                            setTitle(e.target.value);
+                                        }
+                                    }}
+                                />
+                                <FormHelperText sx={{ mb: 1 }}>Enter a title for the dataset.</FormHelperText>
+                                <Typography level="body-xs" color="neutral">
+                                    Only Alpha-numeric characters, Underscores and Hyphens are allowed.
                                 </Typography>
-                            )}
-                        </FormControl>
+                            </FormControl>
 
-                        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
-                            <Button
-                                variant="outlined"
-                                sx={{
-                                    borderColor: "primary.subtle",
-                                    color: "primary.subtle",
-                                    backgroundColor: "white"
-                                }}
-                                onClick={onClose}
-                            >
-                                Cancel
-                            </Button>
-                            <Button
-                                variant="solid"
-                                type="submit"
-                                sx={{ backgroundColor: "primary.main" }}
-                                disabled={!isValid}
-                            >
-                                Create
-                            </Button>
+                            <FormControl required sx={{ mb: 2 }}>
+                                <FormLabel>Description</FormLabel>
+                                <Textarea
+                                    placeholder="Enter a description for the dataset"
+                                    value={description}
+                                    minRows={3}
+                                    maxRows={5}
+                                    onChange={(e) => {
+                                        if (/^[A-Za-z0-9 _-]*$/.test(e.target.value)) {
+                                            setDescription(e.target.value);
+                                        }
+                                    }}
+                                />
+                                <FormHelperText sx={{ mb: 1 }}>Provide a brief description of the dataset.</FormHelperText>
+                                <Typography level="body-xs" color="neutral">
+                                    Only Alpha-numeric characters, Underscores and Hyphens are allowed.
+                                </Typography>
+                            </FormControl>
+
+                            <FormControl required sx={{ mb: 2 }}>
+                                <FormLabel>Selection Method</FormLabel>
+                                <Select value={selectionMethod} onChange={(_e, val) => setSelectionMethod(val as "fips" | "bbox")}
+                                    placeholder="Select a method">
+                                    <Option value="fips">FIPS Lookup</Option>
+                                    <Option value="bbox">Bounding Box</Option>
+                                </Select>
+                            </FormControl>
+
+                            {selectionMethod === "fips" && (
+                                <FormControl error={showError} sx={{ mb: 2 }}>
+                                    <FormLabel required>FIPS Lookup</FormLabel>
+                                    <Autocomplete
+                                        freeSolo
+                                        placeholder="Search by FIPS code, state, or county"
+                                        options={filteredOptions}
+                                        getOptionLabel={(option) =>
+                                            typeof option === "string"
+                                                ? option
+                                                : `${option.fips} - ${option.county}, ${option.state}`
+                                        }
+                                        onBlur={handleBlur}
+                                        value={selectedFips}
+                                        onChange={(_e, newValue) =>
+                                            setSelectedFips(
+                                                typeof newValue === "object" && newValue !== null && "fips" in newValue
+                                                    ? (newValue as FipsEntry).fips
+                                                    : typeof newValue === "string"
+                                                      ? newValue
+                                                      : null
+                                            )
+                                        }
+                                        inputValue={inputValue}
+                                        onInputChange={(_e, newValue) => setInputValue(newValue)}
+                                        renderTags={(value, getTagProps) =>
+                                            value.map((option, index) => (
+                                                <Chip {...getTagProps({ index })} variant="soft" size="sm">
+                                                    {`${option.fips} - ${option.county}`}
+                                                </Chip>
+                                            ))
+                                        }
+                                    />
+                                    <FormHelperText sx={{ mb: 1 }}>
+                                        Search by FIPS code, state, or county name. (Only California, Oregon, and Tennessee are
+                                        available.)
+                                    </FormHelperText>
+                                    {showError && (
+                                        <Typography fontSize="sm" color="danger">
+                                            Please select a FIPS entry.
+                                        </Typography>
+                                    )}
+                                </FormControl>
+                            )}
+
+                            {selectionMethod === "bbox" && (
+                                <Box sx={{ mb: 2 }}>
+                                    <FormLabel>Bounding Box</FormLabel>
+                                    <Typography level="body-sm" color="neutral" sx={{ mb: 1 }}>
+                                        Use the map on the right to draw a bounding box. Check "Draw Bounding Box" and click-drag to create a selection.
+                                    </Typography>
+                                    {/* Live bbox readout for confirmation while drawing */}
+                                    {bbox ? (
+                                        <Box sx={{ mt: 1, p: 1, border: "1px solid #ddd", borderRadius: 4, backgroundColor: "#f5f5f5" }}>
+                                            <Typography level="body-sm" fontWeight="bold">Selected Bounding Box:</Typography>
+                                            <Typography level="body-xs">minx: {bbox[0].toFixed(6)}, miny: {bbox[1].toFixed(6)}</Typography>
+                                            <Typography level="body-xs">maxx: {bbox[2].toFixed(6)}, maxy: {bbox[3].toFixed(6)}</Typography>
+                                        </Box>
+                                    ) : (
+                                        <Box sx={{ mt: 1, p: 1, border: "1px solid #ddd", borderRadius: 4, backgroundColor: "#f5f5f5" }}>
+                                            <Typography level="body-sm" color="neutral">No bounding box selected yet. Draw one on the map.</Typography>
+                                        </Box>
+                                    )}
+                                </Box>
+                            )}
+
+                            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+                                <Button
+                                    variant="outlined"
+                                    sx={{
+                                        borderColor: "primary.subtle",
+                                        color: "primary.subtle",
+                                        backgroundColor: "white"
+                                    }}
+                                    onClick={onClose}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button type="submit">Submit</Button>
+                            </Box>
+                        </form>
+                    </Box>
+
+                    {/* Right side - Map (only when bbox is selected) */}
+                    {selectionMethod === "bbox" && (
+                        <Box sx={{
+                            flex: "0 0 400px",
+                            height: "500px",
+                            backgroundColor: "white",
+                            border: "2px solid #1976d2",
+                            borderRadius: "8px",
+                            boxShadow: "0 4px 20px rgba(0,0,0,0.3)",
+                            position: "relative"
+                        }}>
+                            <Box sx={{
+                                position: "absolute",
+                                top: "-30px",
+                                left: "0",
+                                right: "0",
+                                textAlign: "center",
+                                zIndex: 1002
+                            }}>
+                                <Typography level="body-sm" sx={{
+                                    backgroundColor: "#1976d2",
+                                    color: "white",
+                                    px: 2,
+                                    py: 0.5,
+                                    borderRadius: "4px 4px 0 0",
+                                    display: "inline-block"
+                                }}>
+                                    Bounding Box Selection
+                                </Typography>
+                            </Box>
+                            <BoundingBoxDrawer 
+                                onBboxSelected={handleBboxSelected}
+                                height={500}
+                            />
                         </Box>
-                    </form>
-                </Box>
-            </ModalDialog>
-        </Modal>
+                    )}
+                </ModalDialog>
+            </Modal>
+
+
+
+            {/* Confirmation dialog for bbox */}
+            <Modal open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+                <ModalDialog variant="outlined">
+                    <Typography component="h2" fontSize="lg" fontWeight="bold" sx={{ mb: 1 }}>
+                        Confirm Bounding Box
+                    </Typography>
+                    {bbox ? (
+                        <Box sx={{ mb: 2 }}>
+                            <Typography level="body-sm">minx: {bbox[0].toFixed(6)}</Typography>
+                            <Typography level="body-sm">miny: {bbox[1].toFixed(6)}</Typography>
+                            <Typography level="body-sm">maxx: {bbox[2].toFixed(6)}</Typography>
+                            <Typography level="body-sm">maxy: {bbox[3].toFixed(6)}</Typography>
+                        </Box>
+                    ) : null}
+                    <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+                        <Button
+                            variant="outlined"
+                            sx={{
+                                borderColor: "primary.subtle",
+                                color: "primary.subtle",
+                                backgroundColor: "white"
+                            }}
+                            onClick={() => {
+                                setConfirmOpen(false);
+                                setBbox(null);
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button onClick={() => setConfirmOpen(false)}>Confirm</Button>
+                    </Box>
+                </ModalDialog>
+            </Modal>
+        </>
     );
 };
 

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -23,6 +23,8 @@ import fipsData from "@app/components/Project/Resource/fips.json";
 import { getHeaders } from "@app/utils";
 import config from "@app/app.config";
 import BoundingBoxDrawer from "@app/components/Map/BoundingBoxDrawer";
+import { addDatasetToProject } from "@app/reducer/projectSlice";
+import { useAppDispatch } from "@app/store/hooks";
 
 // Define the shape of a FIPS record
 interface FipsEntry {
@@ -42,6 +44,7 @@ interface FipsLookupModalProps {
 const allowedStates = ["Tennessee", "Oregon", "California"];
 
 const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projectId, handleSnackbar }) => {
+    const appDispatch = useAppDispatch();
     const [inputValue, setInputValue] = React.useState<string>("");
     const [filteredOptions, setFilteredOptions] = React.useState<FipsEntry[]>([]);
     const [selectedFips, setSelectedFips] = React.useState<string | null>(null);
@@ -53,6 +56,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
     // BBox state
     const [bbox, setBbox] = React.useState<[number, number, number, number] | null>(null);
     const [confirmOpen, setConfirmOpen] = React.useState(false);
+    const [processingDialogOpen, setProcessingDialogOpen] = React.useState(false);
 
     const allowedFipsData = (fipsData as FipsEntry[]).filter((entry) => allowedStates.includes(entry.state));
 
@@ -88,23 +92,93 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
     }, [inputValue]);
 
     // Submit handler
-    const handleApply = () => {
-        const payload = {
-            title: title,
-            description: description,
-            hazardType: "earthquake",
-            fips_list: selectedFips ? [selectedFips] : []
-        };
+    const handleApply = async () => {
+        if (selectionMethod === "fips") {
+            // Handle FIPS-based submission
+            const payload = {
+                title: title,
+                description: description,
+                hazardType: "earthquake",
+                fips_list: selectedFips ? [selectedFips] : []
+            };
 
-        try {
-            axios.post(`${config.toolsApi}/bldg-inventory?projectid=${projectId}`, payload, {
-                headers: getHeaders()
-            });
-            handleSnackbar?.("success");
-        } catch (error) {
+            console.log('FIPS Lookup - Submitting with FIPS code:', selectedFips);
+            console.log('FIPS Lookup - Full payload:', payload);
+
+            try {
+                axios.post(`${config.toolsApi}/bldg-inventory?projectid=${projectId}`, payload, {
+                    headers: getHeaders()
+                }).then(response => {
+                    console.log('FIPS Lookup - API call successful:', response.data);
+                }).catch(error => {
+                    console.error("FIPS Lookup - Error creating building inventory dataset:", error);
+                });
+                handleSnackbar?.("success");
+                setProcessingDialogOpen(true);
+            } catch (error) {
+                console.error("FIPS Lookup - Error creating building inventory dataset:", error);
+                handleSnackbar?.("failure");
+            }
+        } else if (selectionMethod === "bbox" && bbox) {
+            // Handle bounding box-based submission
+            const [minLng, minLat, maxLng, maxLat] = bbox;
+            
+            // Create the dataset object with bounding box coordinates
+            // Note: API expects [minY, minX, maxY, maxX] format (lat, lng, lat, lng)
+            const dataset = {
+                title: title || "NSI building inventory dataset",
+                description: description || "Building inventory dataset created with bounding box selection",
+                bounding_box: [minLat, minLng, maxLat, maxLng] // [minY, minX, maxY, maxX] format
+            };
+
+            console.log('Sending bounding box to API:', dataset);
+
+            // Try to use the data service endpoint for bounding box (similar to test file)
+            try {
+                const dataset = {
+                    title: title || "NSI building inventory dataset",
+                    description: description || "Building inventory dataset created with bounding box selection",
+                    bounding_box: [minLat, minLng, maxLat, maxLng] // [minY, minX, maxY, maxX] format
+                };
+
+                            // Create FormData for the API call (matching test file exactly)
+                const formData = new FormData();
+                formData.append('dataset', JSON.stringify(dataset));
+                formData.append('type', 'application/json');
+
+                // Try the data service endpoint first (similar to test file structure)
+                const response = await axios.post(`${config.dataService}/tools/bldg-inventory?projectid=${projectId}`, formData, {
+                    headers: {
+                        ...getHeaders(),
+                        'Content-Type': 'multipart/form-data'
+                    }
+                });
+                console.log('API call successful:', response.data);
+                
+                // Add the created dataset to the project so it shows up in the Dataset page
+                if (response.data && response.data.id && projectId) {
+                    appDispatch(addDatasetToProject({ projectId, datasets: [response.data] }));
+                }
+                
+                handleSnackbar?.("success");
+                setProcessingDialogOpen(true);
+            } catch (error) {
+                console.error('Bounding box API call failed:', error);
+                
+                // If the data service endpoint fails, show a message that bounding box is not yet supported
+                console.log('Bounding box functionality is not yet available in the current API');
+                handleSnackbar?.("failure");
+                
+                // Don't close the modal, let user switch to FIPS or try again
+                return;
+            }
+        } else if (selectionMethod === "bbox" && !bbox) {
+            // Show error if bbox is selected but no bounding box is drawn
             handleSnackbar?.("failure");
-            console.error("Error creating building inventory dataset:", error);
+            console.error("No bounding box selected");
+            return;
         }
+
         onClose();
     };
 
@@ -191,9 +265,9 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                             Currently, the tool supports the following hazards: Earthquake, Tsunami, Flood, Hurricane wind.
                         </Typography>
                         <form
-                            onSubmit={(e) => {
+                            onSubmit={async (e) => {
                                 e.preventDefault();
-                                handleApply();
+                                await handleApply();
                                 onClose();
                             }}
                         >
@@ -240,8 +314,13 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 <Select value={selectionMethod} onChange={(_e, val) => setSelectionMethod(val as "fips" | "bbox")}
                                     placeholder="Select a method">
                                     <Option value="fips">FIPS Lookup</Option>
-                                    <Option value="bbox">Bounding Box</Option>
+                                    <Option value="bbox">Bounding Box (Experimental)</Option>
                                 </Select>
+                                {selectionMethod === "bbox" && (
+                                    <FormHelperText sx={{ mt: 1, color: "warning.500" }}>
+                                        ⚠️ Bounding box functionality is experimental and may not work with the current API. If it fails, please use FIPS lookup instead.
+                                    </FormHelperText>
+                                )}
                             </FormControl>
 
                             {selectionMethod === "fips" && (
@@ -310,19 +389,32 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 </Box>
                             )}
 
-                            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
-                                <Button
-                                    variant="outlined"
-                                    sx={{
-                                        borderColor: "primary.subtle",
-                                        color: "primary.subtle",
-                                        backgroundColor: "white"
-                                    }}
-                                    onClick={onClose}
-                                >
-                                    Cancel
-                                </Button>
-                                <Button type="submit">Submit</Button>
+                            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, flexDirection: "column", alignItems: "flex-end" }}>
+                                {selectionMethod === "bbox" && !bbox && (
+                                    <Typography level="body-xs" color="neutral" sx={{ mb: 1 }}>
+                                        Please draw a bounding box on the map to continue
+                                    </Typography>
+                                )}
+
+                                <Box sx={{ display: "flex", gap: 1 }}>
+                                    <Button
+                                        variant="outlined"
+                                        sx={{
+                                            borderColor: "primary.subtle",
+                                            color: "primary.subtle",
+                                            backgroundColor: "white"
+                                        }}
+                                        onClick={onClose}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button 
+                                        type="submit"
+                                        disabled={selectionMethod === "bbox" && !bbox}
+                                    >
+                                        Submit
+                                    </Button>
+                                </Box>
                             </Box>
                         </form>
                     </Box>
@@ -421,6 +513,34 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 Confirm
                             </Button>
                         ) : null}
+                    </Box>
+                </ModalDialog>
+            </Modal>
+
+            {/* Processing dialog for FIPS dataset creation */}
+            <Modal open={processingDialogOpen} onClose={() => setProcessingDialogOpen(false)}>
+                <ModalDialog variant="outlined">
+                    <Typography component="h2" fontSize="lg" fontWeight="bold" sx={{ mb: 2 }}>
+                        Dataset Creation in Progress
+                    </Typography>
+                    
+                    <Box sx={{ mb: 3 }}>
+                        <Typography level="body-sm" sx={{ mb: 2 }}>
+                            Your building inventory dataset is being created. This process may take several minutes to complete.
+                        </Typography>
+                        <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
+                            You can check the progress by visiting the <strong>Dataset</strong> page in the left sidebar. 
+                            The dataset will appear there once the creation process is finished.
+                        </Typography>
+                        <Typography level="body-sm" color="warning" fontWeight="bold">
+                            ⚠️ Please do not close this browser tab while the dataset is being created.
+                        </Typography>
+                    </Box>
+                    
+                    <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+                        <Button onClick={() => setProcessingDialogOpen(false)}>
+                            OK, I Understand
+                        </Button>
                     </Box>
                 </ModalDialog>
             </Modal>

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -316,11 +316,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                     <Option value="fips">FIPS Lookup</Option>
                                     <Option value="bbox">Bounding Box</Option>
                                 </Select>
-                                {selectionMethod === "bbox" && (
-                                    <FormHelperText sx={{ mt: 1, color: "warning.500" }}>
-                                        ⚠️ Bounding box functionality is experimental and may not work with the current API. If it fails, please use FIPS lookup instead.
-                                    </FormHelperText>
-                                )}
+
                             </FormControl>
 
                             {selectionMethod === "fips" && (

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -314,7 +314,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 <Select value={selectionMethod} onChange={(_e, val) => setSelectionMethod(val as "fips" | "bbox")}
                                     placeholder="Select a method">
                                     <Option value="fips">FIPS Lookup</Option>
-                                    <Option value="bbox">Bounding Box (Experimental)</Option>
+                                    <Option value="bbox">Bounding Box</Option>
                                 </Select>
                                 {selectionMethod === "bbox" && (
                                     <FormHelperText sx={{ mt: 1, color: "warning.500" }}>

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -102,17 +102,20 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                 fips_list: selectedFips ? [selectedFips] : []
             };
 
-            console.log('FIPS Lookup - Submitting with FIPS code:', selectedFips);
-            console.log('FIPS Lookup - Full payload:', payload);
+            console.log("FIPS Lookup - Submitting with FIPS code:", selectedFips);
+            console.log("FIPS Lookup - Full payload:", payload);
 
             try {
-                axios.post(`${config.toolsApi}/bldg-inventory?projectid=${projectId}`, payload, {
-                    headers: getHeaders()
-                }).then(response => {
-                    console.log('FIPS Lookup - API call successful:', response.data);
-                }).catch(error => {
-                    console.error("FIPS Lookup - Error creating building inventory dataset:", error);
-                });
+                axios
+                    .post(`${config.toolsApi}/bldg-inventory?projectid=${projectId}`, payload, {
+                        headers: getHeaders()
+                    })
+                    .then((response) => {
+                        console.log("FIPS Lookup - API call successful:", response.data);
+                    })
+                    .catch((error) => {
+                        console.error("FIPS Lookup - Error creating building inventory dataset:", error);
+                    });
                 handleSnackbar?.("success");
                 setProcessingDialogOpen(true);
             } catch (error) {
@@ -122,7 +125,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
         } else if (selectionMethod === "bbox" && bbox) {
             // Handle bounding box-based submission
             const [minLng, minLat, maxLng, maxLat] = bbox;
-            
+
             // Create the dataset object with bounding box coordinates
             // Note: API expects [minY, minX, maxY, maxX] format (lat, lng, lat, lng)
             const dataset = {
@@ -131,7 +134,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                 bounding_box: [minLat, minLng, maxLat, maxLng] // [minY, minX, maxY, maxX] format
             };
 
-            console.log('Sending bounding box to API:', dataset);
+            console.log("Sending bounding box to API:", dataset);
 
             // Try to use the data service endpoint for bounding box (similar to test file)
             try {
@@ -141,34 +144,38 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                     bounding_box: [minLat, minLng, maxLat, maxLng] // [minY, minX, maxY, maxX] format
                 };
 
-                            // Create FormData for the API call (matching test file exactly)
+                // Create FormData for the API call (matching test file exactly)
                 const formData = new FormData();
-                formData.append('dataset', JSON.stringify(dataset));
-                formData.append('type', 'application/json');
+                formData.append("dataset", JSON.stringify(dataset));
+                formData.append("type", "application/json");
 
                 // Try the data service endpoint first (similar to test file structure)
-                const response = await axios.post(`${config.dataService}/tools/bldg-inventory?projectid=${projectId}`, formData, {
-                    headers: {
-                        ...getHeaders(),
-                        'Content-Type': 'multipart/form-data'
+                const response = await axios.post(
+                    `${config.dataService}/tools/bldg-inventory?projectid=${projectId}`,
+                    formData,
+                    {
+                        headers: {
+                            ...getHeaders(),
+                            "Content-Type": "multipart/form-data"
+                        }
                     }
-                });
-                console.log('API call successful:', response.data);
-                
+                );
+                console.log("API call successful:", response.data);
+
                 // Add the created dataset to the project so it shows up in the Dataset page
                 if (response.data && response.data.id && projectId) {
                     appDispatch(addDatasetToProject({ projectId, datasets: [response.data] }));
                 }
-                
+
                 handleSnackbar?.("success");
                 setProcessingDialogOpen(true);
             } catch (error) {
-                console.error('Bounding box API call failed:', error);
-                
+                console.error("Bounding box API call failed:", error);
+
                 // If the data service endpoint fails, show a message that bounding box is not yet supported
-                console.log('Bounding box functionality is not yet available in the current API');
+                console.log("Bounding box functionality is not yet available in the current API");
                 handleSnackbar?.("failure");
-                
+
                 // Don't close the modal, let user switch to FIPS or try again
                 return;
             }
@@ -196,14 +203,14 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
         const width = maxLng - minLng;
         const height = maxLat - minLat;
         const area = width * height;
-        
+
         // Check individual dimensions (max 1 degree each)
         const exceedsWidth = width > 1.0;
         const exceedsHeight = height > 1.0;
-        
+
         // Check total area (max 1 square degree = 1° × 1°)
         const exceedsArea = area > 1.0;
-        
+
         return exceedsWidth || exceedsHeight || exceedsArea;
     };
 
@@ -211,7 +218,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
     const handleBboxSelected = (selectedBbox: [number, number, number, number]) => {
         console.log("NSI Modal: Received bbox", selectedBbox);
         setBbox(selectedBbox);
-        
+
         // Check if the bounding box is too large
         if (isBboxTooLarge(selectedBbox)) {
             setConfirmOpen(true); // Still show the dialog but with warning message
@@ -231,25 +238,28 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
     return (
         <>
             <Modal open={open} onClose={onClose}>
-                <ModalDialog 
-                    variant="outlined" 
-                    sx={{ 
+                <ModalDialog
+                    variant="outlined"
+                    sx={{
                         maxWidth: selectionMethod === "bbox" ? "90vw" : "60vw",
                         width: selectionMethod === "bbox" ? "90vw" : "60vw",
                         display: "flex",
                         flexDirection: "row",
                         gap: 2,
+                        padding: 5,
                         alignItems: "flex-start"
                     }}
                 >
                     <ModalClose sx={{ zIndex: 20 }} />
-                    
+
                     {/* Left side - Form content */}
-                    <Box sx={{ 
-                        padding: 1, 
-                        flex: "1 1 400px",
-                        minWidth: "400px"
-                    }}>
+                    <Box
+                        sx={{
+                            padding: 1,
+                            flex: "1 1 400px",
+                            minWidth: "400px"
+                        }}
+                    >
                         <Typography
                             id="create-nsi-dataset-dialog-title"
                             component="h2"
@@ -260,9 +270,10 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                             Generate Building Inventory Dataset
                         </Typography>
                         <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
-                            This tool will generate an IN-CORE building inventory dataset based on NSI (National Structure
-                            Inventory) for a FIPS code. The dataset is configured to work with fragility curves for IN-CORE.
-                            Currently, the tool supports the following hazards: Earthquake, Tsunami, Flood, Hurricane wind.
+                            This tool will generate an IN-CORE building inventory dataset based on NSI (National
+                            Structure Inventory) for a FIPS code. The dataset is configured to work with fragility
+                            curves for IN-CORE. Currently, the tool supports the following hazards: Earthquake, Tsunami,
+                            Flood, Hurricane wind.
                         </Typography>
                         <form
                             onSubmit={async (e) => {
@@ -303,7 +314,9 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                         }
                                     }}
                                 />
-                                <FormHelperText sx={{ mb: 1 }}>Provide a brief description of the dataset.</FormHelperText>
+                                <FormHelperText sx={{ mb: 1 }}>
+                                    Provide a brief description of the dataset.
+                                </FormHelperText>
                                 <Typography level="body-xs" color="neutral">
                                     Only Alpha-numeric characters, Underscores and Hyphens are allowed.
                                 </Typography>
@@ -311,12 +324,14 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
 
                             <FormControl required sx={{ mb: 2 }}>
                                 <FormLabel>Selection Method</FormLabel>
-                                <Select value={selectionMethod} onChange={(_e, val) => setSelectionMethod(val as "fips" | "bbox")}
-                                    placeholder="Select a method">
+                                <Select
+                                    value={selectionMethod}
+                                    onChange={(_e, val) => setSelectionMethod(val as "fips" | "bbox")}
+                                    placeholder="Select a method"
+                                >
                                     <Option value="fips">FIPS Lookup</Option>
                                     <Option value="bbox">Bounding Box</Option>
                                 </Select>
-
                             </FormControl>
 
                             {selectionMethod === "fips" && (
@@ -338,8 +353,8 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                                 typeof newValue === "object" && newValue !== null && "fips" in newValue
                                                     ? (newValue as FipsEntry).fips
                                                     : typeof newValue === "string"
-                                                      ? newValue
-                                                      : null
+                                                    ? newValue
+                                                    : null
                                             )
                                         }
                                         inputValue={inputValue}
@@ -353,8 +368,8 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                         }
                                     />
                                     <FormHelperText sx={{ mb: 1 }}>
-                                        Search by FIPS code, state, or county name. (Only California, Oregon, and Tennessee are
-                                        available.)
+                                        Search by FIPS code, state, or county name. (Only California, Oregon, and
+                                        Tennessee are available.)
                                     </FormHelperText>
                                     {showError && (
                                         <Typography fontSize="sm" color="danger">
@@ -368,24 +383,57 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 <Box sx={{ mb: 2 }}>
                                     <FormLabel>Bounding Box</FormLabel>
                                     <Typography level="body-sm" color="neutral" sx={{ mb: 1 }}>
-                                        Use the map on the right to draw a bounding box. Check "Draw Bounding Box" and click-drag to create a selection.
+                                        Use the map on the right to draw a bounding box. Check "Draw Bounding Box" and
+                                        click-drag to create a selection.
                                     </Typography>
                                     {/* Live bbox readout for confirmation while drawing */}
                                     {bbox ? (
-                                        <Box sx={{ mt: 1, p: 1, border: "1px solid #ddd", borderRadius: 4, backgroundColor: "#f5f5f5" }}>
-                                            <Typography level="body-sm" fontWeight="bold">Selected Bounding Box:</Typography>
-                                            <Typography level="body-xs">minx: {bbox[0].toFixed(6)}, miny: {bbox[1].toFixed(6)}</Typography>
-                                            <Typography level="body-xs">maxx: {bbox[2].toFixed(6)}, maxy: {bbox[3].toFixed(6)}</Typography>
+                                        <Box
+                                            sx={{
+                                                mt: 1,
+                                                p: 1,
+                                                border: "1px solid #ddd",
+                                                borderRadius: 4,
+                                                backgroundColor: "#f5f5f5"
+                                            }}
+                                        >
+                                            <Typography level="body-sm" fontWeight="bold">
+                                                Selected Bounding Box:
+                                            </Typography>
+                                            <Typography level="body-xs">
+                                                minx: {bbox[0].toFixed(6)}, miny: {bbox[1].toFixed(6)}
+                                            </Typography>
+                                            <Typography level="body-xs">
+                                                maxx: {bbox[2].toFixed(6)}, maxy: {bbox[3].toFixed(6)}
+                                            </Typography>
                                         </Box>
                                     ) : (
-                                        <Box sx={{ mt: 1, p: 1, border: "1px solid #ddd", borderRadius: 4, backgroundColor: "#f5f5f5" }}>
-                                            <Typography level="body-sm" color="neutral">No bounding box selected yet. Draw one on the map.</Typography>
+                                        <Box
+                                            sx={{
+                                                mt: 1,
+                                                p: 1,
+                                                border: "1px solid #ddd",
+                                                borderRadius: 4,
+                                                backgroundColor: "#f5f5f5"
+                                            }}
+                                        >
+                                            <Typography level="body-sm" color="neutral">
+                                                No bounding box selected yet. Draw one on the map.
+                                            </Typography>
                                         </Box>
                                     )}
                                 </Box>
                             )}
 
-                            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, flexDirection: "column", alignItems: "flex-end" }}>
+                            <Box
+                                sx={{
+                                    display: "flex",
+                                    justifyContent: "flex-end",
+                                    gap: 1,
+                                    flexDirection: "column",
+                                    alignItems: "flex-end"
+                                }}
+                            >
                                 {selectionMethod === "bbox" && !bbox && (
                                     <Typography level="body-xs" color="neutral" sx={{ mb: 1 }}>
                                         Please draw a bounding box on the map to continue
@@ -404,10 +452,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                     >
                                         Cancel
                                     </Button>
-                                    <Button 
-                                        type="submit"
-                                        disabled={selectionMethod === "bbox" && !bbox}
-                                    >
+                                    <Button type="submit" disabled={selectionMethod === "bbox" && !bbox}>
                                         Submit
                                     </Button>
                                 </Box>
@@ -417,44 +462,46 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
 
                     {/* Right side - Map (only when bbox is selected) */}
                     {selectionMethod === "bbox" && (
-                        <Box sx={{
-                            flex: "0 0 400px",
-                            height: "500px",
-                            backgroundColor: "white",
-                            border: "2px solid #1976d2",
-                            borderRadius: "8px",
-                            boxShadow: "0 4px 20px rgba(0,0,0,0.3)",
-                            position: "relative"
-                        }}>
-                            <Box sx={{
-                                position: "absolute",
-                                top: "-30px",
-                                left: "0",
-                                right: "0",
-                                textAlign: "center",
-                                zIndex: 1002
-                            }}>
-                                <Typography level="body-sm" sx={{
-                                    backgroundColor: "#1976d2",
-                                    color: "white",
-                                    px: 2,
-                                    py: 0.5,
-                                    borderRadius: "4px 4px 0 0",
-                                    display: "inline-block"
-                                }}>
+                        <Box
+                            sx={{
+                                flex: "0 0 400px",
+                                height: "500px",
+                                backgroundColor: "white",
+                                border: "2px solid #1976d2",
+                                borderRadius: "8px",
+                                boxShadow: "0 4px 20px rgba(0,0,0,0.3)",
+                                position: "relative"
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    position: "absolute",
+                                    top: "-30px",
+                                    left: "0",
+                                    right: "0",
+                                    textAlign: "center",
+                                    zIndex: 1002
+                                }}
+                            >
+                                <Typography
+                                    level="body-sm"
+                                    sx={{
+                                        backgroundColor: "#1976d2",
+                                        color: "white",
+                                        px: 2,
+                                        py: 0.5,
+                                        borderRadius: "4px 4px 0 0",
+                                        display: "inline-block"
+                                    }}
+                                >
                                     Bounding Box Selection
                                 </Typography>
                             </Box>
-                            <BoundingBoxDrawer 
-                                onBboxSelected={handleBboxSelected}
-                                height={500}
-                            />
+                            <BoundingBoxDrawer onBboxSelected={handleBboxSelected} height={500} />
                         </Box>
                     )}
                 </ModalDialog>
             </Modal>
-
-
 
             {/* Confirmation dialog for bbox */}
             <Modal open={confirmOpen} onClose={() => setConfirmOpen(false)}>
@@ -462,25 +509,29 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                     <Typography component="h2" fontSize="lg" fontWeight="bold" sx={{ mb: 1 }}>
                         {bbox && isBboxTooLarge(bbox) ? "Error: Bounding Box Too Large" : "Confirm Bounding Box"}
                     </Typography>
-                    
+
                     {bbox && isBboxTooLarge(bbox) && (
-                        <Box sx={{ 
-                            mb: 2, 
-                            p: 2, 
-                            backgroundColor: "#f8d7da", 
-                            border: "1px solid #f5c6cb", 
-                            borderRadius: "4px",
-                            borderLeft: "4px solid #dc3545"
-                        }}>
+                        <Box
+                            sx={{
+                                mb: 2,
+                                p: 2,
+                                backgroundColor: "#f8d7da",
+                                border: "1px solid #f5c6cb",
+                                borderRadius: "4px",
+                                borderLeft: "4px solid #dc3545"
+                            }}
+                        >
                             <Typography level="body-sm" color="danger" fontWeight="bold" sx={{ mb: 1 }}>
                                 ❌ Selected bounding box exceeds the maximum allowed size
                             </Typography>
                             <Typography level="body-sm" color="neutral">
-                                The selected area exceeds the maximum allowed size. Please select an area where both width and height are no more than 1 degree, and the total area is no more than 1 square degree.
+                                The selected area exceeds the maximum allowed size. Please select an area where both
+                                width and height are no more than 1 degree, and the total area is no more than 1 square
+                                degree.
                             </Typography>
                         </Box>
                     )}
-                    
+
                     {bbox ? (
                         <Box sx={{ mb: 2 }}>
                             <Typography level="body-sm">minx: {bbox[0].toFixed(6)}</Typography>
@@ -505,9 +556,7 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                             {bbox && isBboxTooLarge(bbox) ? "OK" : "Cancel"}
                         </Button>
                         {!bbox || !isBboxTooLarge(bbox) ? (
-                            <Button onClick={() => setConfirmOpen(false)}>
-                                Confirm
-                            </Button>
+                            <Button onClick={() => setConfirmOpen(false)}>Confirm</Button>
                         ) : null}
                     </Box>
                 </ModalDialog>
@@ -519,24 +568,23 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                     <Typography component="h2" fontSize="lg" fontWeight="bold" sx={{ mb: 2 }}>
                         Dataset Creation in Progress
                     </Typography>
-                    
+
                     <Box sx={{ mb: 3 }}>
                         <Typography level="body-sm" sx={{ mb: 2 }}>
-                            Your building inventory dataset is being created. This process may take several minutes to complete.
+                            Your building inventory dataset is being created. This process may take several minutes to
+                            complete.
                         </Typography>
                         <Typography level="body-sm" color="neutral" sx={{ mb: 2 }}>
-                            You can check the progress by visiting the <strong>Dataset</strong> page in the left sidebar. 
-                            The dataset will appear there once the creation process is finished.
+                            You can check the progress by visiting the <strong>Dataset</strong> page in the left
+                            sidebar. The dataset will appear there once the creation process is finished.
                         </Typography>
                         <Typography level="body-sm" color="warning" fontWeight="bold">
                             ⚠️ Please do not close this browser tab while the dataset is being created.
                         </Typography>
                     </Box>
-                    
+
                     <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                        <Button onClick={() => setProcessingDialogOpen(false)}>
-                            OK, I Understand
-                        </Button>
+                        <Button onClick={() => setProcessingDialogOpen(false)}>OK, I Understand</Button>
                     </Box>
                 </ModalDialog>
             </Modal>

--- a/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
+++ b/src/components/Project/Resource/NSIBuildingInventoryTool.tsx
@@ -108,11 +108,42 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
         onClose();
     };
 
+    // Calculate area of bounding box in square degrees (approximate)
+    const calculateBboxArea = (bbox: [number, number, number, number]): number => {
+        const [minLng, minLat, maxLng, maxLat] = bbox;
+        const width = maxLng - minLng;
+        const height = maxLat - minLat;
+        return width * height;
+    };
+
+    // Check if bounding box is too large (checking both area and individual dimensions)
+    const isBboxTooLarge = (bbox: [number, number, number, number]): boolean => {
+        const [minLng, minLat, maxLng, maxLat] = bbox;
+        const width = maxLng - minLng;
+        const height = maxLat - minLat;
+        const area = width * height;
+        
+        // Check individual dimensions (max 1 degree each)
+        const exceedsWidth = width > 1.0;
+        const exceedsHeight = height > 1.0;
+        
+        // Check total area (max 1 square degree = 1° × 1°)
+        const exceedsArea = area > 1.0;
+        
+        return exceedsWidth || exceedsHeight || exceedsArea;
+    };
+
     // Handle bbox selection from BoundingBoxDrawer
     const handleBboxSelected = (selectedBbox: [number, number, number, number]) => {
         console.log("NSI Modal: Received bbox", selectedBbox);
         setBbox(selectedBbox);
-        setConfirmOpen(true);
+        
+        // Check if the bounding box is too large
+        if (isBboxTooLarge(selectedBbox)) {
+            setConfirmOpen(true); // Still show the dialog but with warning message
+        } else {
+            setConfirmOpen(true); // Show normal confirmation
+        }
     };
 
     // Clear bbox when switching to FIPS
@@ -341,8 +372,27 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
             <Modal open={confirmOpen} onClose={() => setConfirmOpen(false)}>
                 <ModalDialog variant="outlined">
                     <Typography component="h2" fontSize="lg" fontWeight="bold" sx={{ mb: 1 }}>
-                        Confirm Bounding Box
+                        {bbox && isBboxTooLarge(bbox) ? "Error: Bounding Box Too Large" : "Confirm Bounding Box"}
                     </Typography>
+                    
+                    {bbox && isBboxTooLarge(bbox) && (
+                        <Box sx={{ 
+                            mb: 2, 
+                            p: 2, 
+                            backgroundColor: "#f8d7da", 
+                            border: "1px solid #f5c6cb", 
+                            borderRadius: "4px",
+                            borderLeft: "4px solid #dc3545"
+                        }}>
+                            <Typography level="body-sm" color="danger" fontWeight="bold" sx={{ mb: 1 }}>
+                                ❌ Selected bounding box exceeds the maximum allowed size
+                            </Typography>
+                            <Typography level="body-sm" color="neutral">
+                                The selected area exceeds the maximum allowed size. Please select an area where both width and height are no more than 1 degree, and the total area is no more than 1 square degree.
+                            </Typography>
+                        </Box>
+                    )}
+                    
                     {bbox ? (
                         <Box sx={{ mb: 2 }}>
                             <Typography level="body-sm">minx: {bbox[0].toFixed(6)}</Typography>
@@ -364,9 +414,13 @@ const FipsLookupModal: React.FC<FipsLookupModalProps> = ({ open, onClose, projec
                                 setBbox(null);
                             }}
                         >
-                            Cancel
+                            {bbox && isBboxTooLarge(bbox) ? "OK" : "Cancel"}
                         </Button>
-                        <Button onClick={() => setConfirmOpen(false)}>Confirm</Button>
+                        {!bbox || !isBboxTooLarge(bbox) ? (
+                            <Button onClick={() => setConfirmOpen(false)}>
+                                Confirm
+                            </Button>
+                        ) : null}
                     </Box>
                 </ModalDialog>
             </Modal>


### PR DESCRIPTION
This PR is for adding the bounding box based selection for the NSI building inventory dataset. 

- In the dev instance, there are only three states, so when you do the selection, please only do in NC, OR, and TN. 
- There is a size limitation that is around 1 degree by 1 degree to avoid the incore-services burden. The size should be a little bit bigger (around 1.5 times) than Champaign County
- After the drawing bounding box, there will be a confirmation message box 
- If the bounding box is too big, it will give you the warning message box

**How to test.**
- Run by npm run start:dev
- Go to http://localhost:3000 in your browser
- Login using IN-CORE credential
- Open any project on the page, maybe TEST NSI one
- Select Tools from the left side menu
- Click NSI building inventory
- When "Generate Building Inventory Dataset" menu pops up, select the Bounding Box option
- Draw a Bounding Box on the map, only select from the three states mentioned above
- Also, fill up the Title and Description
- Submit
- Check the dataset menu from the left side menu
- You will see the dataset you just created from there

**Please make sure to delete the dataset you made during the test from data viewer**

Currently, in the dataset menu, if you test the View option, it doesn't work. It is because the geoserver doesn't work correctly when the new dataset gets posted. This should be fixed to make everything work correctly, and this should be done in another issue.
