### PR TITLE
Updated CHANGELOG and set version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Re-run execution with same parameters copied error over to the new execution. [#256](https://github.com/IN-CORE/incore-studio/issues/256)
+
 ## [1.1.0] - 08-11-2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.2.0] - 12-12-2025
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "incore-studio",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "incore-studio",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "dependencies": {
                 "@dagrejs/dagre": "^1.1.4",
                 "@emotion/react": "^11.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "incore-studio",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "private": true,
     "main": "src/App.tsx",
     "engines": {

--- a/src/components/Execution/CreateExecutionDialog.tsx
+++ b/src/components/Execution/CreateExecutionDialog.tsx
@@ -74,8 +74,12 @@ const CreateExecutionDialog = (props: CreateExecutionDialogProps) => {
                     description,
                     workflowId: wfId,
                     deleted: false,
-                    parameters: currentExecution.parameters,
-                    datasets: currentExecution.datasets
+                    parameters: Object.fromEntries(
+                        Object.entries(currentExecution.parameters).filter(([key]) => key in createExecution.parameters)
+                    ),
+                    datasets: Object.fromEntries(
+                        Object.entries(currentExecution.datasets).filter(([key]) => key in createExecution.datasets)
+                    )
                 };
                 const result = await appDispatch(createNewExecution(newExecution));
                 resetReRun();


### PR DESCRIPTION
Release 1.2.0 - fixes issue with resubmitting workflows with previous parameters. If the previous run had errors, it was copying over the bad data to the next run.